### PR TITLE
Bug PM-137: Countdown on closed/resolved market still showing

### DIFF
--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -245,6 +245,11 @@ class MarketDetail extends Component {
       .diff(moment(), 'hours')
     const { marketShares } = this.props
 
+    const marketClosedOrFinished = (
+      market.stage === MARKET_STAGES.MARKET_CLOSED ||
+      market.oracle.isOutcomeSet
+    )
+
     const winnings = marketShares.reduce((sum, share) => {
       const shareWinnings = weiToEth(
         calcLMSRProfit({
@@ -265,7 +270,7 @@ class MarketDetail extends Component {
           <p className="marketDescription__text">{market.eventDescription.description}</p>
         </div>
         <Outcome market={market} />
-        {timeToResolution < ONE_WEEK_IN_HOURS ? (
+        {!marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS ? (
           <div className="marketTimer">
             <div className="marketTimer__live">
               <Countdown target={market.eventDescription.resolutionDate} />
@@ -279,12 +284,18 @@ class MarketDetail extends Component {
           </div>
         ) : (
           <div className="marketTimer">
+            <div className="marketTimer__live marketTimer__live--big">
+              <div className="marketTimer__liveLabel">Resolution Time</div>
+            </div>
             <div className="marketTimer__live">
               {moment
                 .utc(market.eventDescription.resolutionDate)
                 .local()
                 .format(RESOLUTION_TIME.ABSOLUTE_FORMAT)}
             </div>
+            {marketClosedOrFinished && (
+                <div className="marketTimer__marketClosed">{timeToResolution < 0 ? 'This market was resolved.' : 'This market was closed.'}</div>
+            )}
           </div>
         )}
         {showWinning &&
@@ -307,9 +318,9 @@ class MarketDetail extends Component {
             </div>
           )}
       </div>
-    )
-  }
-
+      )
+    }
+    
   renderControls() {
     const { market, closeMarket, defaultAccount } = this.props
     return (

--- a/src/components/MarketDetail/marketDetail.less
+++ b/src/components/MarketDetail/marketDetail.less
@@ -67,6 +67,26 @@
 }
 
 .marketTimer__live {
+  &--big {
+    font-size: 24px;
+  }
+  &Label {
+    color: @font-color-muted;
+    font-size: 18px;
+    text-transform: uppercase;
+  }
+  font-size: 22px;
+  font-weight: 300;
+  letter-spacing: 1px;
+  line-height: 1.2;
+  @media (min-width: @screen-sm) {
+    font-size: 28px;
+  }
+}
+
+
+.marketTimer__marketClosed {
+  margin-top: 20px;
   font-size: 22px;
   font-weight: 300;
   letter-spacing: 1px;

--- a/src/components/MarketList/index.js
+++ b/src/components/MarketList/index.js
@@ -56,6 +56,7 @@ class MarketList extends Component {
   @autobind
     handleViewMarket(market) {
         this.props.changeUrl(`/markets/${market.address}`)
+        window.scroll(0, 0)
     }
 
   @autobind
@@ -64,12 +65,14 @@ class MarketList extends Component {
         event.stopPropagation()
 
         this.props.changeUrl(resolveUrl)
+        window.scroll(0, 0)
     }
 
   @autobind
     handleCreateMarket() {
         if (this.props.defaultAccount) {
             this.props.changeUrl('/markets/new')
+            window.scroll(0, 0)
         }
     }
 


### PR DESCRIPTION
Also fixed three UI/UX problems:

- Page now scrolls up when entering the market details
- Indication added for "This market was resolved" and "This market was closed"
- Added Label over Resolution time, if only resolution time shows, otherwise it's confusing