### PR TITLE
Feature: PM-151 add limit margin for buying and selling

### DIFF
--- a/src/actions/market.js
+++ b/src/actions/market.js
@@ -389,7 +389,7 @@ export const buyMarketShares = (
  * @param {number} outcomeIndex - Index of outcome to sell shares of
  * @param {number|string|BigNumber} outcomeTokenCount - Amount of tokenshares to sell
  */
-export const sellMarketShares = (market, outcomeIndex, outcomeTokenCount) => async (dispatch) => {
+export const sellMarketShares = (market, outcomeIndex, outcomeTokenCount, earnings) => async (dispatch) => {
   const transactionId = uuid()
   const gnosis = await api.getGnosisConnection()
 
@@ -406,7 +406,7 @@ export const sellMarketShares = (market, outcomeIndex, outcomeTokenCount) => asy
   dispatch(openModal({ modalName: 'ModalTransactionsExplanation', transactions }))
 
   try {
-    await api.sellShares(market.address, outcomeIndex, outcomeTokenCount)
+    await api.sellShares(market.address, outcomeIndex, outcomeTokenCount, earnings)
     await dispatch(closeEntrySuccess, transactionId, TRANSACTION_STAGES.GENERIC)
     gaSend(['event', 'Transactions', 'uport', 'Sell shares transactions succeeded'])
     await dispatch(closeModal())

--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -245,13 +245,13 @@ export const buyShares = async (market, outcomeTokenIndex, outcomeTokenCount, co
   // Markets on Gnosis has by default Ether Token as collateral Token, that has 18 decimals
   // Outcome tokens have also 18 decimals
   // The decimal values represent an offset of 18 positions on the integer value
-  const collateralTokenWei = Decimal(cost).mul(1e18)
+  const collateralTokenWei = Decimal(cost).mul(1e18).toString()
 
   // The user needs to deposit amount of collateral tokens willing to pay before performing the buy
   const collateralToken = await gnosis.contracts.HumanFriendlyToken.at(await gnosis.contracts.Event.at(market.event.address).collateralToken())
 
   if ((await collateralToken.name()) === 'Ether Token') {
-    await gnosis.etherToken.deposit({ value: collateralTokenWei.toString() })
+    await gnosis.etherToken.deposit({ value: collateralTokenWei })
   }
 
   // buyOutComeTokens handles approving
@@ -259,6 +259,7 @@ export const buyShares = async (market, outcomeTokenIndex, outcomeTokenCount, co
     market: market.address,
     outcomeTokenIndex,
     outcomeTokenCount: outcomeTokenCount.toString(),
+    cost: collateralTokenWei,
     approvalResetAmount,
   })
 

--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -272,17 +272,25 @@ export const resolveEvent = async (event, selectedOutcomeIndex) => {
   await gnosis.resolveEvent(event.address, parseInt(selectedOutcomeIndex, 10))
 }
 
-export const sellShares = async (marketAddress, outcomeTokenIndex, outcomeTokenCount, approvalResetAmount) => {
+export const sellShares = async (
+  marketAddress,
+  outcomeTokenIndex,
+  outcomeTokenCount,
+  earnings,
+  approvalResetAmount,
+) => {
   const gnosis = await getGnosisConnection()
 
   const outcomeTokenCountWei = Decimal(outcomeTokenCount)
     .mul(1e18)
     .toString()
+  const minProfit = Decimal(earnings).mul(1e18).round().toString()
 
   const collateralTokensReceived = await gnosis.sellOutcomeTokens({
     market: hexWithPrefix(marketAddress),
     outcomeTokenIndex,
     outcomeTokenCount: outcomeTokenCountWei,
+    minProfit,
     approvalResetAmount,
   })
 

--- a/src/components/MarketBuySharesForm/index.js
+++ b/src/components/MarketBuySharesForm/index.js
@@ -6,7 +6,10 @@ import autobind from 'autobind-decorator'
 import { calcLMSROutcomeTokenCount, calcLMSRMarginalPrice } from 'api'
 
 import { weiToEth } from 'utils/helpers'
-import { COLOR_SCHEME_DEFAULT, OUTCOME_TYPES, GAS_COST, SCALAR_SHORT_COLOR, SCALAR_LONG_COLOR } from 'utils/constants'
+import {
+  COLOR_SCHEME_DEFAULT, OUTCOME_TYPES, GAS_COST,
+  SCALAR_SHORT_COLOR, SCALAR_LONG_COLOR, LIMIT_MARGIN_DEFAULT,
+} from 'utils/constants'
 import { marketShape, marketShareShape } from 'utils/shapes'
 
 import InteractionButton from 'containers/InteractionButton'
@@ -34,12 +37,14 @@ class MarketBuySharesForm extends Component {
     }
   }
 
-  getOutcomeTokenCount(investment, outcomeIndex) {
+  getOutcomeTokenCount(investment, outcomeIndex, limitMargin) {
     if (!investment || !(parseFloat(investment) > 0) || parseFloat(investment) >= 1000) {
       return new Decimal(0)
     }
 
     const invest = new Decimal(investment).mul(1e18)
+      .div(new Decimal(100).add(limitMargin == null ? LIMIT_MARGIN_DEFAULT : limitMargin).toString()).mul(100)
+      .round()
     const { market: { funding, netOutcomeTokensSold, fee } } = this.props
 
     let outcomeTokenCount
@@ -78,10 +83,10 @@ class MarketBuySharesForm extends Component {
   @autobind
   handleBuyShares() {
     const {
-      market, buyShares, selectedBuyInvest, reset, defaultAccount, selectedOutcome,
+      market, buyShares, selectedBuyInvest, reset, defaultAccount, selectedOutcome, limitMargin
     } = this.props
 
-    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome)
+    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome, limitMargin)
 
     return buyShares(market, selectedOutcome, outcomeTokenCount, selectedBuyInvest).then(() => {
       // Fetch new trades
@@ -121,10 +126,10 @@ class MarketBuySharesForm extends Component {
 
   renderCategorical() {
     const {
-      selectedBuyInvest, selectedOutcome, market, market: { eventDescription },
+      selectedBuyInvest, selectedOutcome, limitMargin, market, market: { eventDescription }
     } = this.props
 
-    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome)
+    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome, limitMargin)
 
     return (
       <div className="col-md-7">
@@ -176,6 +181,7 @@ class MarketBuySharesForm extends Component {
     const {
       selectedBuyInvest,
       selectedOutcome,
+      limitMargin,
       market: {
         event: { lowerBound, upperBound },
         eventDescription: { decimals, unit },
@@ -187,7 +193,7 @@ class MarketBuySharesForm extends Component {
     const isOutcomeSelected = selectedOutcome !== undefined
     const currentMarginalPrice = marginalPrices[1]
     // Get the amount of tokens to buy
-    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome)
+    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome, limitMargin)
     const newNetOutcomeTokenSold = netOutcomeTokensSold.slice()
     if (isOutcomeSelected) {
       newNetOutcomeTokenSold[selectedOutcome] = new Decimal(newNetOutcomeTokenSold[selectedOutcome])
@@ -259,6 +265,7 @@ class MarketBuySharesForm extends Component {
       selectedBuyInvest,
       submitFailed,
       submitting,
+      limitMargin,
       market: { event: { collateralToken }, address, local },
       selectedOutcome,
       gasCosts,
@@ -268,7 +275,7 @@ class MarketBuySharesForm extends Component {
 
     const noOutcomeSelected = typeof selectedOutcome === 'undefined'
     // Get the amount of tokens to buy
-    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome)
+    const outcomeTokenCount = this.getOutcomeTokenCount(selectedBuyInvest, selectedOutcome, limitMargin)
     const maximumWin = this.getMaximumWin(outcomeTokenCount, selectedBuyInvest || '0')
     const percentageWin = this.getPercentageWin(outcomeTokenCount, selectedBuyInvest)
     const gasCostEstimation = weiToEth(gasPrice.mul(gasCosts.buyShares || 0))
@@ -324,6 +331,18 @@ class MarketBuySharesForm extends Component {
                     <CurrencyName collateralToken={collateralToken} />
                   </div>
                 </div>
+              </div>
+              <div className="row marketBuySharesForm__row">
+                <div className="col-md-6">Limit Margin in %</div>
+                <div className="col-md-3">
+                  <Field
+                    name="limitMargin"
+                    component={Input}
+                    className="limitMarginField"
+                    placeholder={LIMIT_MARGIN_DEFAULT}
+                  />
+                </div>
+                <div className="col-md-3">%</div>
               </div>
               <div className="row marketBuySharesForm__row">
                 <div className="col-md-6">Token Count</div>
@@ -385,6 +404,7 @@ MarketBuySharesForm.propTypes = {
   marketShares: PropTypes.arrayOf(marketShareShape),
   selectedOutcome: PropTypes.number,
   selectedBuyInvest: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  limitMargin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   handleSubmit: PropTypes.func,
   submitEnabled: PropTypes.bool,
   currentBalance: PropTypes.string,

--- a/src/components/MarketBuySharesForm/index.js
+++ b/src/components/MarketBuySharesForm/index.js
@@ -43,7 +43,7 @@ class MarketBuySharesForm extends Component {
     }
 
     const invest = new Decimal(investment).mul(1e18)
-      .div(new Decimal(100).add(limitMargin == null ? LIMIT_MARGIN_DEFAULT : limitMargin).toString()).mul(100)
+      .div(new Decimal(100).add(limitMargin == null ? LIMIT_MARGIN_DEFAULT : limitMargin)).mul(100)
       .round()
     const { market: { funding, netOutcomeTokensSold, fee } } = this.props
 

--- a/src/components/MarketBuySharesForm/marketBuySharesForm.less
+++ b/src/components/MarketBuySharesForm/marketBuySharesForm.less
@@ -64,6 +64,10 @@
   }
 }
 
+.limitMarginField {
+  margin: 0;
+}
+
 .marketBuyCurrency {
   height: 100%;
   font-size: 32px;

--- a/src/components/MarketMySharesForm/index.js
+++ b/src/components/MarketMySharesForm/index.js
@@ -13,7 +13,7 @@ import CurrencyName from 'components/CurrencyName'
 
 import FormInput from 'components/FormInput'
 
-import { COLOR_SCHEME_DEFAULT, GAS_COST, LOWEST_DISPLAYED_VALUE, MIN_CONSIDER_VALUE } from 'utils/constants'
+import { COLOR_SCHEME_DEFAULT, GAS_COST, LOWEST_DISPLAYED_VALUE, MIN_CONSIDER_VALUE, LIMIT_MARGIN_DEFAULT } from 'utils/constants'
 import { getOutcomeName, weiToEth, normalizeScalarPoint } from 'utils/helpers'
 import { marketShape } from 'utils/shapes'
 
@@ -203,6 +203,7 @@ class MarketMySharesForm extends Component {
       submitting,
       submitFailed,
       selectedSellAmount,
+      limitMargin,
       handleSubmit,
       marketShares,
       gasCosts,
@@ -341,6 +342,15 @@ class MarketMySharesForm extends Component {
           </div>
           <div className="row">
             <div className="col-md-3 col-md-offset-3">
+              <label for="limitMargin">Limit Margin in %</label>
+              <Field
+                component={FormInput}
+                name="limitMargin"
+                placeholder={LIMIT_MARGIN_DEFAULT}
+                className="limitMarginField"
+              />
+            </div>
+            <div className="col-md-3 col-md-offset-3">
               <label>Gas costs</label>
               <span>
                 <DecimalValue value={gasCostEstimation} decimals={5} />&nbsp;
@@ -419,6 +429,7 @@ MarketMySharesForm.propTypes = {
   ...propTypes,
   market: marketShape,
   selectedSellAmount: PropTypes.string,
+  limitMargin: PropTypes.string,
   marketShares: PropTypes.arrayOf(PropTypes.object),
   sellShares: PropTypes.func,
 }

--- a/src/components/MarketMySharesForm/index.js
+++ b/src/components/MarketMySharesForm/index.js
@@ -254,9 +254,7 @@ class MarketMySharesForm extends Component {
           outcomeTokenIndex: share.outcomeToken.index,
           outcomeTokenCount: selectedSellAmountWei,
           feeFactor: market.fee,
-        }).mul(
-          new Decimal(100).sub(sellLimitMargin == null ? LIMIT_MARGIN_DEFAULT : sellLimitMargin).toString(),
-        ).div(100),
+        }).mul(new Decimal(100).sub(sellLimitMargin == null ? LIMIT_MARGIN_DEFAULT : sellLimitMargin)).div(100),
       )
     }
 

--- a/src/containers/MarketDetailPage/index.js
+++ b/src/containers/MarketDetailPage/index.js
@@ -38,6 +38,7 @@ const mapStateToProps = (state, ownProps) => {
     marketShares: getMarketSharesByMarket(state)(ownProps.params.id, getCurrentAccount(state)),
     selectedOutcome: marketBuySelector(state, 'selectedOutcome'),
     selectedBuyInvest: marketBuySelector(state, 'invest'),
+    limitMargin: marketBuySelector(state, 'limitMargin'),
     selectedSellAmount: marketMySharesSelector(state, 'sellAmount'),
     selectedShortSellAmount: marketShortSellSelector(state, 'shortSellAmount'),
     selectedShortSellOutcome: marketShortSellSelector(state, 'selectedOutcome'),

--- a/src/containers/MarketDetailPage/index.js
+++ b/src/containers/MarketDetailPage/index.js
@@ -40,6 +40,7 @@ const mapStateToProps = (state, ownProps) => {
     selectedBuyInvest: marketBuySelector(state, 'invest'),
     limitMargin: marketBuySelector(state, 'limitMargin'),
     selectedSellAmount: marketMySharesSelector(state, 'sellAmount'),
+    sellLimitMargin: marketMySharesSelector(state, 'limitMargin'),
     selectedShortSellAmount: marketShortSellSelector(state, 'shortSellAmount'),
     selectedShortSellOutcome: marketShortSellSelector(state, 'selectedOutcome'),
     hasWallet: checkWalletConnection(state),
@@ -67,8 +68,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchMarketTrades: market => dispatch(requestMarketTrades(market)),
   buyShares: (market, outcomeIndex, outcomeTokenCount, cost) =>
     dispatch(buyMarketShares(market, outcomeIndex, outcomeTokenCount, cost)),
-  sellShares: (market, outcomeIndex, outcomeTokenCount) =>
-    dispatch(sellMarketShares(market, outcomeIndex, outcomeTokenCount)),
+  sellShares: (market, outcomeIndex, outcomeTokenCount, earnings) =>
+    dispatch(sellMarketShares(market, outcomeIndex, outcomeTokenCount, earnings)),
   resolveMarket: (market, outcomeIndex) => dispatch(resolveMarket(market, outcomeIndex)),
   changeUrl: url => dispatch(replace(url)),
   redeemWinnings: market => dispatch(redeemWinnings(market)),

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -78,3 +78,5 @@ export const TRANSACTION_DESCRIPTIONS = {
   BUY: 'BOUGHT',
   SELL: 'SOLD',
 }
+
+export const LIMIT_MARGIN_DEFAULT = '5'


### PR DESCRIPTION
Quote from internal:

> If two people have buy transactions for the same outcome in the same block, one of the transactions will fail because the price for that outcome will change. We will introduce a margin (5%?) for which a market participant will be willing to pay extra for their outcome token to mitigate this issue.
> 
> This will not completely eliminate the issue since large orders can still change the price past this margin, but hopefully it will allow normal trading to happen.