### PR TITLE
Feature PM-178 Delay reset data account and uport stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "d3": "^4.9.1",
     "d3-scale-chromatic": "^1.1.1",
     "decimal.js": "^7.2.3",
+    "jsontokens": "^0.7.6",
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "moment-duration-format": "^1.3.0",

--- a/src/actions/blockchain.js
+++ b/src/actions/blockchain.js
@@ -1,6 +1,5 @@
 import {
   initGnosisConnection,
-  getGnosisConnection,
   getOlympiaTokensByAccount,
   getCurrentBalance,
   getCurrentAccount,
@@ -144,18 +143,16 @@ export const runProviderUpdate = (provider, data) => async (dispatch, getState) 
 
   if (provider.constructor.providerName === 'UPORT') {
     await dispatch(initGnosis())
-    const account = (await getGnosisConnection()).defaultAccount
-    const balance = await getOlympiaTokensByAccount(account)
+    const balance = await getOlympiaTokensByAccount(data.account)
     await dispatch(
       updateProvider({
         ...data,
         provider: provider.constructor.providerName,
-        account,
         balance: weiToEth(balance),
       }),
     )
 
-    await dispatch(fetchOlympiaUserData(account))
+    await dispatch(fetchOlympiaUserData(data.account))
   }
 }
 

--- a/src/actions/blockchain.js
+++ b/src/actions/blockchain.js
@@ -16,7 +16,7 @@ import {
 import { timeoutCondition, getGnosisJsOptions } from 'utils/helpers'
 import { GAS_COST } from 'utils/constants'
 import { createAction } from 'redux-actions'
-import { findDefaultProvider, isGnosisInitialized, getUportDefaultAccount } from 'selectors/blockchain'
+import { findDefaultProvider, isGnosisInitialized } from 'selectors/blockchain'
 
 // TODO define reducer for GnosisStatus
 export const setGnosisInitialized = createAction('SET_GNOSIS_CONNECTION')
@@ -144,11 +144,8 @@ export const runProviderUpdate = (provider, data) => async (dispatch, getState) 
   }
 }
 
-export const runProviderRegister = (provider, data) => async (dispatch, getState) => {
+export const runProviderRegister = (provider, data) => async (dispatch) => {
   const providerData = { ...data }
-  if (provider.constructor.providerName === 'UPORT') {
-    providerData.account = getUportDefaultAccount(getState())
-  }
   await dispatch(
     registerProvider({
       provider: provider.constructor.providerName,

--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -9,8 +9,6 @@ import delay from 'await-delay'
 import moment from 'moment'
 import Decimal from 'decimal.js'
 
-import uPortInstance, { requestCredentials } from 'integrations/uport/connector'
-
 let gnosisInstance
 
 export const calcLMSRCost = Gnosis.calcLMSRCost
@@ -247,13 +245,6 @@ export const closeMarket = async (market) => {
 export const buyShares = async (market, outcomeTokenIndex, outcomeTokenCount, cost, approvalResetAmount) => {
   const gnosis = await getGnosisConnection()
 
-  if (uPortInstance.firstReq) {
-    // set firstReq to false so uPort intro modal is not shown
-
-    uPortInstance.firstReq = false
-    await requestCredentials()
-  }
-
   // Markets on Gnosis has by default Ether Token as collateral Token, that has 18 decimals
   // Outcome tokens have also 18 decimals
   // The decimal values represent an offset of 18 positions on the integer value
@@ -286,13 +277,6 @@ export const resolveEvent = async (event, selectedOutcomeIndex) => {
 export const sellShares = async (marketAddress, outcomeTokenIndex, outcomeTokenCount, approvalResetAmount) => {
   const gnosis = await getGnosisConnection()
 
-  if (uPortInstance.firstReq) {
-    // set firstReq to false so uPort intro modal is not shown
-
-    uPortInstance.firstReq = false
-    await requestCredentials()
-  }
-
   const outcomeTokenCountWei = Decimal(outcomeTokenCount)
     .mul(1e18)
     .toString()
@@ -308,13 +292,6 @@ export const sellShares = async (marketAddress, outcomeTokenIndex, outcomeTokenC
 export const redeemWinnings = async (eventType, eventAddress) => {
   const gnosis = await getGnosisConnection()
 
-  if (uPortInstance.firstReq) {
-    // set firstReq to false so uPort intro modal is not shown
-
-    uPortInstance.firstReq = false
-    await requestCredentials()
-  }
-
   const eventContract =
     eventType === OUTCOME_TYPES.CATEGORICAL
       ? await gnosis.contracts.CategoricalEvent.at(eventAddress)
@@ -328,13 +305,6 @@ export const redeemWinnings = async (eventType, eventAddress) => {
 
 export const withdrawFees = async (marketAddress) => {
   const gnosis = await getGnosisConnection()
-
-  if (uPortInstance.firstReq) {
-    // set firstReq to false so uPort intro modal is not shown
-
-    uPortInstance.firstReq = false
-    await requestCredentials()
-  }
 
   const marketContract = gnosis.contracts.Market.at(marketAddress)
 

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -8,17 +8,13 @@ import Hairline from 'components/layout/Hairline'
 import PageFrame from 'components/layout/PageFrame'
 import TransitionGroup from 'react-transition-group/TransitionGroup'
 import CSSTransition from 'react-transition-group/CSSTransition'
-
-import { initProviders } from 'actions/blockchain'
-
 import LoadingIndicator from 'components/LoadingIndicator'
-
 import TransactionFloaterContainer from 'containers/TransactionFloaterContainer'
 import HeaderContainer from 'containers/HeaderContainer'
 import { providerPropType } from 'utils/shapes'
 
 import { getSelectedProvider, isConnectedToCorrectNetwork } from 'selectors/blockchain'
-import initGoogleAnalytics from 'utils/analytics/init'
+
 
 import './app.less'
 
@@ -29,11 +25,6 @@ class App extends Component {
         app_id: process.env.INTERCOM_ID,
       })
     }
-  }
-
-  componentDidMount() {
-    initGoogleAnalytics()
-    this.props.initProviders()
   }
 
   render() {
@@ -74,7 +65,6 @@ App.propTypes = {
   blockchainConnection: PropTypes.bool,
   children: PropTypes.node,
   location: PropTypes.object,
-  initProviders: PropTypes.func.isRequired,
   provider: providerPropType,
 }
 
@@ -84,6 +74,4 @@ const mapStateToProps = state => ({
   isConnectedToCorrectNetwork: isConnectedToCorrectNetwork(state),
 })
 
-export default connect(mapStateToProps, {
-  initProviders,
-})(App)
+export default connect(mapStateToProps)(App)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill'
 import 'whatwg-fetch'
-
+import { initProviders } from 'actions/blockchain'
 import React from 'react'
 
 import ReactDOM from 'react-dom'
@@ -9,8 +9,8 @@ import { browserHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import { AppContainer } from 'react-hot-loader'
 import 'less/style.less'
-
 import AppRouter from 'router'
+import initGoogleAnalytics from 'utils/analytics/init'
 import BackdropProvider from 'containers/BackdropProvider'
 import store from 'store'
 import { setMomentRelativeTime } from './setup'
@@ -19,6 +19,9 @@ setMomentRelativeTime()
 
 // load data from localstorage
 store.dispatch({ type: 'INIT' })
+store.dispatch(initProviders())
+
+initGoogleAnalytics()
 
 /* global document */
 const rootElement = document.getElementById('root')

--- a/src/integrations/remote/index.js
+++ b/src/integrations/remote/index.js
@@ -40,6 +40,8 @@ class Remote extends BaseIntegration {
       account: this.account,
       balance: this.balance,
     })
+    .then(() => opts.initGnosis())
+    .catch(() => opts.initGnosis())
   }
 }
 

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -11,6 +11,10 @@ const uport = new Connect('Gnosis', {
 export default uport
 
 export const requestCredentials = async () => {
-  const cred = await uport.requestCredentials({ notifications: true })
-  localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
+  try {
+    const cred = await uport.requestCredentials({ notifications: true })
+    localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
+  } catch (err) {
+    localStorage.removeItem(UPORT_OLYMPIA_KEY)
+  }
 }

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -1,3 +1,4 @@
+import { decodeToken } from 'jsontokens'
 import { Connect, SimpleSigner } from 'uport-connect'
 
 export const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
@@ -17,4 +18,29 @@ export const requestCredentials = async () => {
   } catch (err) {
     localStorage.removeItem(UPORT_OLYMPIA_KEY)
   }
+}
+
+export const getCredentialsFromLocalStorage = () => {
+  const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
+
+  return cred ? JSON.parse(cred) : cred
+}
+
+export const hasValidCredential = () => {
+  const cred = getCredentialsFromLocalStorage()
+  if (cred === null) {
+    return false
+  }
+
+  const pushToken = decodeToken(cred.pushToken)
+  if (!pushToken) {
+    return false
+  }
+
+  const expiration = pushToken.payload.exp // When the uPort credential will expire
+  const oneDay = 24 * 60 * 6 // one day in seconds
+  const now = new Date() / 1000 // in seconds
+  const isValid = (expiration - oneDay) > now
+
+  return isValid
 }

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -1,5 +1,7 @@
 import { Connect, SimpleSigner } from 'uport-connect'
 
+export const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
+
 const uport = new Connect('Gnosis', {
   clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
   network: 'rinkeby',
@@ -9,5 +11,6 @@ const uport = new Connect('Gnosis', {
 export default uport
 
 export const requestCredentials = async () => {
-  await uport.requestCredentials({ notifications: true })
+  const cred = await uport.requestCredentials({ notifications: true })
+  localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
 }

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -3,7 +3,7 @@ import { WALLET_PROVIDER } from 'integrations/constants'
 import BaseIntegration from 'integrations/baseIntegration'
 import { fetchOlympiaUserData } from 'routes/scoreboard/store/actions'
 import { weiToEth } from 'utils/helpers'
-import uPortInstance, { requestCredentials, UPORT_OLYMPIA_KEY } from './connector'
+import uPortInstance, { hasValidCredential, requestCredentials, getCredentialsFromLocalStorage } from './connector'
 
 class Uport extends BaseIntegration {
   static providerName = WALLET_PROVIDER.UPORT
@@ -21,15 +21,6 @@ class Uport extends BaseIntegration {
     super({ enableWatcher, watcherTimeout })
   }
 
-  hasCredentials() {
-    return window.localStorage.getItem(UPORT_OLYMPIA_KEY) !== null
-  }
-
-  getCredentialsFromLocalStorage() {
-    const cred = window.localStorage.getItem(UPORT_OLYMPIA_KEY)
-
-    return JSON.parse(cred)
-  }
   /**
    * Tries to initialize and enable the current provider
    * @param {object} opts - Integration Options
@@ -45,7 +36,7 @@ class Uport extends BaseIntegration {
 
     this.uport = uPortInstance
 
-    if (!this.hasCredentials()) {
+    if (!hasValidCredential()) {
       await requestCredentials()
     }
 
@@ -54,7 +45,7 @@ class Uport extends BaseIntegration {
     this.network = await this.getNetwork()
     this.networkId = await this.getNetworkId()
 
-    const cred = this.getCredentialsFromLocalStorage()
+    const cred = getCredentialsFromLocalStorage()
 
     if (cred) {
       this.uport.address = cred.address

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -38,7 +38,10 @@ class Uport extends BaseIntegration {
    */
   async initialize(opts) {
     super.initialize(opts)
-    this.runProviderRegister(this, { priority: Uport.providerPriority })
+    this.runProviderRegister(this, {
+      priority: Uport.providerPriority,
+      account: opts.uportDefaultAccount,
+    })
 
     this.uport = uPortInstance
 
@@ -75,6 +78,7 @@ class Uport extends BaseIntegration {
       opts.runProviderUpdate(this, {
         provider: Uport.providerName,
         balance: weiToEth(balance),
+        account: this.account,
       })
       opts.dispatch(fetchOlympiaUserData(this.account))
     })

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -1,6 +1,6 @@
 import { WALLET_PROVIDER } from 'integrations/constants'
 import BaseIntegration from 'integrations/baseIntegration'
-import uPortInstance, { requestCredentials } from './connector'
+import uPortInstance, { requestCredentials, UPORT_OLYMPIA_KEY } from './connector'
 
 class Uport extends BaseIntegration {
   static providerName = WALLET_PROVIDER.UPORT
@@ -18,6 +18,15 @@ class Uport extends BaseIntegration {
     super({ enableWatcher, watcherTimeout })
   }
 
+  hasCredentials() {
+    return window.localStorage.getItem(UPORT_OLYMPIA_KEY) !== null
+  }
+
+  getCredentialsFromLocalStorage() {
+    const cred = window.localStorage.getItem(UPORT_OLYMPIA_KEY)
+
+    return JSON.parse(cred)
+  }
   /**
    * Tries to initialize and enable the current provider
    * @param {object} opts - Integration Options
@@ -30,10 +39,15 @@ class Uport extends BaseIntegration {
 
     this.uport = uPortInstance
 
-    if (!opts.uportDefaultAccount) {
-      this.uport.firstReq = true
+    if (!this.hasCredentials()) {
       await requestCredentials()
     }
+
+    const cred = this.getCredentialsFromLocalStorage()
+
+    this.uport.address = cred.address
+    this.uport.pushToken = cred.pushToken
+    this.uport.publicEncKey = cred.publicEncKey
 
     this.web3 = await this.uport.getWeb3()
     this.provider = await this.uport.getProvider()

--- a/src/middlewares/Providers.js
+++ b/src/middlewares/Providers.js
@@ -13,11 +13,11 @@ export default store => next => (action) => {
       runProviderUpdate: (provider, data) => dispatch(runProviderUpdate(provider, data)),
       runProviderRegister: (provider, data) => dispatch(runProviderRegister(provider, data)),
       uportDefaultAccount: getUportDefaultAccount(getState()),
+      initGnosis: () => dispatch(initGnosis()),
+      dispatch,
     }
 
     Promise.all(map(walletIntegrations, integration => integration.initialize(providerOptions)))
-      .then(() => dispatch(initGnosis()))
-      .catch(() => dispatch(initGnosis()))
   }
 
   return handledAction

--- a/src/middlewares/Providers.js
+++ b/src/middlewares/Providers.js
@@ -16,8 +16,8 @@ export default store => next => (action) => {
     }
 
     Promise.all(map(walletIntegrations, integration => integration.initialize(providerOptions)))
-      .then(dispatch(initGnosis()), dispatch(initGnosis()))
-      .catch(dispatch(initGnosis()))
+      .then(() => dispatch(initGnosis()))
+      .catch(() => dispatch(initGnosis()))
   }
 
   return handledAction


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //Storybook components
- [ ] Documentation

**Description**
This PR solves the problem when the token account was reset after a fail in a transaction. Also contains commits for making the app more stable (uport related).

*  Forcing to only init wallet providers once
* Moved specific code of uport to its provider class
* Storing Uport credentials and re-using them when refreshing the page
* Checking expiration date of credentials and remove them if they are about to expire
* Removed uport's hacks before doing operations