### PR TITLE
PM-197 > Show only winning outcome

### DIFF
--- a/src/components/OutcomeCategorical/index.js
+++ b/src/components/OutcomeCategorical/index.js
@@ -21,56 +21,61 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
     return marginalPrice.toFixed()
   })
 
+  // show only treding outcome
   if (showOnlyTrendingOutcome && !market.oracle.isOutcomeSet) {
     const tokenDistributionInt = tokenDistribution.map(outcome => parseInt(parseFloat(outcome) * 10000, 10))
     const trendingOutcomeIndex = tokenDistributionInt.indexOf(Math.max(...tokenDistributionInt))
+    const outcomeEntryStyle = {
+      backgroundColor: COLOR_SCHEME_DEFAULT[trendingOutcomeIndex],
+    }
+    const treningMarginalPricePercent = market.marginalPrices
+      ? Math.round(market.marginalPrices[trendingOutcomeIndex] * 100).toFixed(0)
+      : 0
+
     return (
       <div className="outcomes outcomes--categorical">
-        <div className="entry__color" style={{ backgroundColor: COLOR_SCHEME_DEFAULT[trendingOutcomeIndex] }} />
+        <div className="entry__color" style={outcomeEntryStyle} />
         <div className="outcome">{renderOutcomes[trendingOutcomeIndex]}</div>
-        <div>
-          {market.marginalPrices ? Math.round(market.marginalPrices[trendingOutcomeIndex] * 100).toFixed(0) : 0}%
-        </div>
+        <div>{treningMarginalPricePercent}%</div>
         <div className="date">{showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''}</div>
       </div>
     )
   }
 
+  // show only winning outcome
   if (market.oracle.isOutcomeSet && market.oracle.outcome !== undefined) {
+    const tokenDistributionPercent = `${Math.round(tokenDistribution[market.oracle.outcome] * 100).toFixed(0)}%`
+
     return (
       <div className={`${className} outcomes outcomes--categorical`}>
         <div className="outcome outcome__winning">
           {renderOutcomes[market.oracle.outcome]}
-          <div className="outcome__bar--value">{`${Math.round(tokenDistribution[market.oracle.outcome] * 100).toFixed(
-            0,
-          )}%`}</div>
+          <div className="outcome__bar--value">{tokenDistributionPercent}</div>
         </div>
       </div>
     )
   }
 
+  // show all outcomes
   return (
     <div className={`${className} outcomes outcomes--categorical`}>
       {renderOutcomes.map((outcome, outcomeIndex) => {
         if (market.oracle.isOutcomeSet && market.oracle.outcome !== outcomeIndex) {
           return <div key={outcomeIndex} className="outcome" />
         }
+        const outcomeBarStyle = {
+          width: `${tokenDistribution[outcomeIndex] * 100}%`,
+          backgroundColor: COLOR_SCHEME_DEFAULT[outcomeIndex],
+        }
+        const tokenDistributionPercent = `${Math.round(tokenDistribution[outcomeIndex] * 100).toFixed(0)}%`
 
         return (
           <div key={outcomeIndex} className="outcome">
             <div className="outcome__bar">
-              <div
-                className="outcome__bar--inner"
-                style={{
-                  width: `${tokenDistribution[outcomeIndex] * 100}%`,
-                  backgroundColor: COLOR_SCHEME_DEFAULT[outcomeIndex],
-                }}
-              >
+              <div className="outcome__bar--inner" style={outcomeBarStyle}>
                 <div className="outcome__bar--label">
                   {renderOutcomes[outcomeIndex]}
-                  <div className="outcome__bar--value">{`${Math.round(tokenDistribution[outcomeIndex] * 100).toFixed(
-                    0,
-                  )}%`}</div>
+                  <div className="outcome__bar--value">{tokenDistributionPercent}</div>
                 </div>
               </div>
             </div>

--- a/src/components/OutcomeCategorical/index.js
+++ b/src/components/OutcomeCategorical/index.js
@@ -28,15 +28,15 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
     const outcomeEntryStyle = {
       backgroundColor: COLOR_SCHEME_DEFAULT[trendingOutcomeIndex],
     }
-    const treningMarginalPricePercent = market.marginalPrices
+    const trendingMarginalPricePercent = market.marginalPrices
       ? Math.round(market.marginalPrices[trendingOutcomeIndex] * 100).toFixed(0)
-      : 0
+      : '0'
 
     return (
       <div className="outcomes outcomes--categorical">
         <div className="entry__color" style={outcomeEntryStyle} />
         <div className="outcome">{renderOutcomes[trendingOutcomeIndex]}</div>
-        <div>{treningMarginalPricePercent}%</div>
+        <div>{trendingMarginalPricePercent}%</div>
         <div className="date">{showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''}</div>
       </div>
     )

--- a/src/components/OutcomeCategorical/index.js
+++ b/src/components/OutcomeCategorical/index.js
@@ -10,6 +10,7 @@ import './outcomeCategorical.less'
 
 const OutcomeCategorical = ({ market, opts = {} }) => {
   const renderOutcomes = market.eventDescription.outcomes
+  const showOnlyWinningOutcome = market.oracle.isOutcomeSet && market.oracle.outcome !== undefined
   const { showOnlyTrendingOutcome, showDate, dateFormat, className } = opts
   const tokenDistribution = renderOutcomes.map((outcome, outcomeIndex) => {
     const marginalPrice = calcLMSRMarginalPrice({
@@ -31,19 +32,20 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
     const trendingMarginalPricePercent = market.marginalPrices
       ? Math.round(market.marginalPrices[trendingOutcomeIndex] * 100).toFixed(0)
       : '0'
+    const resolutionDateFormatted = showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''
 
     return (
       <div className="outcomes outcomes--categorical">
         <div className="entry__color" style={outcomeEntryStyle} />
         <div className="outcome">{renderOutcomes[trendingOutcomeIndex]}</div>
         <div>{trendingMarginalPricePercent}%</div>
-        <div className="date">{showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''}</div>
+        <div className="date">{resolutionDateFormatted}</div>
       </div>
     )
   }
 
   // show only winning outcome
-  if (market.oracle.isOutcomeSet && market.oracle.outcome !== undefined) {
+  if (showOnlyWinningOutcome) {
     const tokenDistributionPercent = `${Math.round(tokenDistribution[market.oracle.outcome] * 100).toFixed(0)}%`
 
     return (

--- a/src/components/OutcomeCategorical/index.js
+++ b/src/components/OutcomeCategorical/index.js
@@ -27,12 +27,23 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
     return (
       <div className="outcomes outcomes--categorical">
         <div className="entry__color" style={{ backgroundColor: COLOR_SCHEME_DEFAULT[trendingOutcomeIndex] }} />
-        <div className="outcome">{ renderOutcomes[trendingOutcomeIndex] }</div>
+        <div className="outcome">{renderOutcomes[trendingOutcomeIndex]}</div>
         <div>
           {market.marginalPrices ? Math.round(market.marginalPrices[trendingOutcomeIndex] * 100).toFixed(0) : 0}%
         </div>
-        <div className="date">
-          { showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''}
+        <div className="date">{showDate ? moment(market.eventDescription.resolutionDate).format(dateFormat) : ''}</div>
+      </div>
+    )
+  }
+
+  if (market.oracle.isOutcomeSet && market.oracle.outcome !== undefined) {
+    return (
+      <div className={`${className} outcomes outcomes--categorical`}>
+        <div className="outcome outcome__winning">
+          {renderOutcomes[market.oracle.outcome]}
+          <div className="outcome__bar--value">{`${Math.round(tokenDistribution[market.oracle.outcome] * 100).toFixed(
+            0,
+          )}%`}</div>
         </div>
       </div>
     )
@@ -50,11 +61,16 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
             <div className="outcome__bar">
               <div
                 className="outcome__bar--inner"
-                style={{ width: `${tokenDistribution[outcomeIndex] * 100}%`, backgroundColor: COLOR_SCHEME_DEFAULT[outcomeIndex] }}
+                style={{
+                  width: `${tokenDistribution[outcomeIndex] * 100}%`,
+                  backgroundColor: COLOR_SCHEME_DEFAULT[outcomeIndex],
+                }}
               >
                 <div className="outcome__bar--label">
-                  { renderOutcomes[outcomeIndex] }
-                  <div className="outcome__bar--value">{ `${Math.round(tokenDistribution[outcomeIndex] * 100).toFixed(0)}%` }</div>
+                  {renderOutcomes[outcomeIndex]}
+                  <div className="outcome__bar--value">{`${Math.round(tokenDistribution[outcomeIndex] * 100).toFixed(
+                    0,
+                  )}%`}</div>
                 </div>
               </div>
             </div>
@@ -67,7 +83,12 @@ const OutcomeCategorical = ({ market, opts = {} }) => {
 
 OutcomeCategorical.propTypes = {
   market: marketShape,
-  opts: PropTypes.object,
+  opts: PropTypes.shape({
+    className: PropTypes.string,
+    showOnlyTrendingOutcome: PropTypes.bool,
+    showDate: PropTypes.bool,
+    dateFormat: PropTypes.string,
+  }),
 }
 
 export default OutcomeCategorical

--- a/src/components/OutcomeCategorical/outcomeCategorical.less
+++ b/src/components/OutcomeCategorical/outcomeCategorical.less
@@ -59,6 +59,7 @@
       margin: 10px 0 10px 3px;
       align-items: center;
       justify-content: flex-start;
+      text-transform: uppercase;
     }
   }
 

--- a/src/components/OutcomeCategorical/outcomeCategorical.less
+++ b/src/components/OutcomeCategorical/outcomeCategorical.less
@@ -53,6 +53,13 @@
     &__label {
       display: inline-block;
     }
+
+    &__winning {
+      display: flex;
+      margin: 10px 0 10px 3px;
+      align-items: center;
+      justify-content: flex-start;
+    }
   }
 
   .date {


### PR DESCRIPTION
**BACKMERGE** https://github.com/gnosis/gnosis-management/pull/146

**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR solves:
> The resolved market "testing" shows the outcome YES 60% as a bar. We should only display the outcome name "YES" as outcome.

Before:
![image-2017-11-17-17-21-38-888](https://user-images.githubusercontent.com/4266059/33078363-bdab9f3a-ced2-11e7-8cdb-0f9dcbad8869.png)

After: