### PR TITLE
PM-208 Check statuses for the markets

### DIFF
--- a/src/components/MarketDetail/ExpandableViews.js
+++ b/src/components/MarketDetail/ExpandableViews.js
@@ -4,7 +4,7 @@ import MarketMySharesForm from 'components/MarketMySharesForm'
 import MarketWithdrawFeesForm from 'components/MarketWithdrawFeesForm'
 import MarketMyTrades from 'components/MarketMyTrades'
 import Decimal from 'decimal.js'
-import { MARKET_STAGES } from 'utils/constants'
+import { isMarketClosed, isMarketResolved } from '../../utils/helpers'
 
 export const EXPAND_BUY_SHARES = 'buy-shares'
 export const EXPAND_MY_TRADES = 'my-trades'
@@ -22,8 +22,8 @@ const expandableViews = ({
       !props.market.local &&
       props.defaultAccount &&
       props.defaultAccount !== props.market.owner &&
-      !props.market.oracle.isOutcomeSet &&
-      props.market.stage !== MARKET_STAGES.MARKET_CLOSED,
+      !isMarketClosed(props.market) &&
+      !isMarketResolved(props.market),
   },
   /* HIDDEN
   [EXPAND_SHORT_SELL]: {
@@ -57,7 +57,7 @@ const expandableViews = ({
       props.market &&
       props.defaultAccount &&
       props.defaultAccount === props.market.oracle.owner &&
-      !props.market.oracle.isOutcomeSet,
+      !isMarketClosed(props.market),
   },
   [EXPAND_WITHDRAW_FEES]: {
     label: 'Withdraw fees',

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -188,6 +188,7 @@ class MarketDetail extends Component {
     const marketResolved = market.oracle.isOutcomeSet
     const marketClosedOrFinished = marketClosed || marketResolved
     const marketStatus = marketResolved ? 'resolved.' : 'closed.'
+    const showCountdown = !marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS && resolutionDateNotPassed
 
     const winnings = marketShares.reduce((sum, share) => {
       const shareWinnings = weiToEth(calcLMSRProfit({
@@ -207,7 +208,7 @@ class MarketDetail extends Component {
           <p className="marketDescription__text">{market.eventDescription.description}</p>
         </div>
         <Outcome market={market} />
-        {!marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS && resolutionDateNotPassed ? (
+        {showCountdown ? (
           <div className="marketTimer">
             <div className="marketTimer__live">
               <Countdown target={market.eventDescription.resolutionDate} />
@@ -231,9 +232,7 @@ class MarketDetail extends Component {
                 .format(RESOLUTION_TIME.ABSOLUTE_FORMAT)}
             </div>
             {marketClosedOrFinished && (
-              <div className="marketTimer__marketClosed">
-                {`This market was ${marketStatus}`}
-              </div>
+              <div className="marketTimer__marketClosed">{`This market was ${marketStatus}`}</div>
             )}
           </div>
         )}
@@ -333,7 +332,14 @@ class MarketDetail extends Component {
           </div>
         </div>
         {this.renderControls(market)}
-        <div ref={(div) => { this.divSharesNode = div }} className="expandable">{this.renderExpandableContent()}</div>
+        <div
+          ref={(div) => {
+            this.divSharesNode = div
+          }}
+          className="expandable"
+        >
+          {this.renderExpandableContent()}
+        </div>
         {market.trades ? <MarketGraph data={market.trades} market={market} /> : ''}
       </div>
     )

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -340,7 +340,7 @@ class MarketDetail extends Component {
         >
           {this.renderExpandableContent()}
         </div>
-        {market.trades ? <MarketGraph data={market.trades} market={market} /> : ''}
+        {market.trades && <MarketGraph data={market.trades} market={market} />}
       </div>
     )
   }

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -23,7 +23,7 @@ import config from 'config.json'
 import expandableViews, { EXPAND_MY_SHARES } from './ExpandableViews'
 
 import './marketDetail.less'
-import { weiToEth } from '../../utils/helpers'
+import { weiToEth, isMarketClosed, isMarketResolved } from '../../utils/helpers'
 import { marketShareShape } from '../../utils/shapes'
 
 const ONE_WEEK_IN_HOURS = 168
@@ -176,7 +176,6 @@ class MarketDetail extends Component {
   }
 
   renderDetails(market) {
-    const showWinning = market.oracle.isOutcomeSet
     const timeToResolution = moment
       .utc(market.eventDescription.resolutionDate)
       .local()
@@ -184,11 +183,12 @@ class MarketDetail extends Component {
     const { marketShares } = this.props
     const resolutionDateNotPassed = moment(market.eventDescription.resolutionDate).isAfter(moment())
 
-    const marketClosed = market.stage === MARKET_STAGES.MARKET_CLOSED
-    const marketResolved = market.oracle.isOutcomeSet
+    const marketClosed = isMarketClosed(market)
+    const marketResolved = isMarketResolved(market)
+    const showWinning = marketResolved
     const marketClosedOrFinished = marketClosed || marketResolved
     const marketStatus = marketResolved ? 'resolved.' : 'closed.'
-    const showCountdown = !marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS && resolutionDateNotPassed
+    const showCountdown = !marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS
 
     const winnings = marketShares.reduce((sum, share) => {
       const shareWinnings = weiToEth(calcLMSRProfit({

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -182,6 +182,7 @@ class MarketDetail extends Component {
       .local()
       .diff(moment(), 'hours')
     const { marketShares } = this.props
+    const resolutionDateNotPassed = moment(market.eventDescription.resolutionDate).isAfter(moment())
 
     const marketClosed = market.stage === MARKET_STAGES.MARKET_CLOSED
     const marketResolved = market.oracle.isOutcomeSet
@@ -206,7 +207,7 @@ class MarketDetail extends Component {
           <p className="marketDescription__text">{market.eventDescription.description}</p>
         </div>
         <Outcome market={market} />
-        {!marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS ? (
+        {!marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS && resolutionDateNotPassed ? (
           <div className="marketTimer">
             <div className="marketTimer__live">
               <Countdown target={market.eventDescription.resolutionDate} />

--- a/src/components/MarketList/index.js
+++ b/src/components/MarketList/index.js
@@ -4,6 +4,7 @@ import autobind from 'autobind-decorator'
 import moment from 'moment'
 import cn from 'classnames'
 import Decimal from 'decimal.js'
+import { Link } from 'react-router'
 import 'moment-duration-format'
 import { reduxForm, Field } from 'redux-form'
 import InteractionButton from 'containers/InteractionButton'
@@ -80,8 +81,29 @@ class MarketList extends Component {
   @autobind
   renderMarket(market) {
     const isResolved = market.oracle && market.oracle.isOutcomeSet
+    const isClosed = market.stage === MARKET_STAGES.MARKET_CLOSED
+    const isResolvedOrClosed = isResolved || isClosed
     const isOwner = this.props.defaultAccount && market.creator === this.props.defaultAccount
     const showResolveButton = isOwner && !isResolved
+
+    let marketStatusInfoField = (
+      <div className="info_field">
+        <div className="info__field--icon icon icon--countdown" />
+        <div className="info__field--label">
+          <Countdown target={market.eventDescription.resolutionDate} format={RESOLUTION_TIME.RELATIVE_FORMAT} />
+        </div>
+      </div>
+    )
+
+    if (isResolvedOrClosed) {
+      const marketStatus = isResolved ? 'resolved' : 'closed'
+      marketStatusInfoField = (
+        <div className="info_field">
+          <div className="info__field--icon icon icon--checkmark" />
+          <div className="info__field--label">{marketStatus}</div>
+        </div>
+      )
+    }
 
     return (
       <button
@@ -105,23 +127,9 @@ class MarketList extends Component {
         </div>
         <Outcome market={market} />
         <div className="market__info row">
-          {isResolved ? (
-            <div className="info__group col-md-3">
-              <div className="info_field">
-                <div className="info__field--icon icon icon--checkmark" />
-                <div className="info__field--label">Resolved</div>
-              </div>
-            </div>
-          ) : (
-            <div className="info__group col-md-3">
-              <div className="info__field">
-                <div className="info__field--icon icon icon--countdown" />
-                <div className="info__field--label">
-                  <Countdown target={market.eventDescription.resolutionDate} format={RESOLUTION_TIME.RELATIVE_FORMAT} />
-                </div>
-              </div>
-            </div>
-          )}
+          <div className="info__group col-md-3">
+            <div className="info__field">{marketStatusInfoField}</div>
+          </div>
           <div className="info__group col-md-3">
             <div className="info__field">
               <div className="info__field--icon icon icon--enddate" />
@@ -210,7 +218,8 @@ class MarketList extends Component {
     const now = new Date()
     const openMarketsAmount = markets.filter(({ stage, oracle: { isOutcomeSet } }) => stage !== MARKET_STAGES.MARKET_CLOSED && !isOutcomeSet).length
     const endingSoonMarketsAmount = markets.filter(({ eventDescription: { resolutionDate } }) => new Date(resolutionDate) - now < threeDayMSeconds).length
-    const newMarketsAmount = markets.filter(({ creationDate }) => now - new Date(creationDate) < threeDayMSeconds).length
+    const newMarketsAmount = markets.filter(({ creationDate }) => now - new Date(creationDate) < threeDayMSeconds)
+      .length
 
     return (
       <div className="marketListPage">

--- a/src/components/MarketList/index.js
+++ b/src/components/MarketList/index.js
@@ -81,11 +81,6 @@ class MarketList extends Component {
 
   @autobind
   renderMarket(market) {
-    console.log('-------------------------')
-    console.log(market)
-    console.log(isMarketClosed(market), 'IS CLOSED?')
-    console.log(isMarketResolved(market), 'IS RESOLVED?')
-    console.log('-------------------------')
     const isResolved = isMarketResolved(market)
     const isClosed = isMarketClosed(market)
     const isResolvedOrClosed = isResolved || isClosed

--- a/src/components/MarketList/index.js
+++ b/src/components/MarketList/index.js
@@ -26,6 +26,7 @@ import { marketShape } from 'utils/shapes'
 
 import './marketList.less'
 import { MARKET_STAGES } from '../../utils/constants'
+import { isMarketClosed, isMarketResolved } from '../../utils/helpers'
 
 const resolutionFilters = [
   {
@@ -80,8 +81,13 @@ class MarketList extends Component {
 
   @autobind
   renderMarket(market) {
-    const isResolved = market.oracle && market.oracle.isOutcomeSet
-    const isClosed = market.stage === MARKET_STAGES.MARKET_CLOSED
+    console.log('-------------------------')
+    console.log(market)
+    console.log(isMarketClosed(market), 'IS CLOSED?')
+    console.log(isMarketResolved(market), 'IS RESOLVED?')
+    console.log('-------------------------')
+    const isResolved = isMarketResolved(market)
+    const isClosed = isMarketClosed(market)
     const isResolvedOrClosed = isResolved || isClosed
     const isOwner = this.props.defaultAccount && market.creator === this.props.defaultAccount
     const showResolveButton = isOwner && !isResolved
@@ -110,7 +116,7 @@ class MarketList extends Component {
         type="button"
         className={cn({
           market,
-          'market--resolved': isResolved,
+          'market--resolved': isResolved || isClosed,
         })}
         key={market.address}
         onClick={() => this.handleViewMarket(market)}
@@ -216,9 +222,10 @@ class MarketList extends Component {
 
     const threeDayMSeconds = 3 * 24 * 60 * 60 * 1000
     const now = new Date()
-    const openMarketsAmount = markets.filter(({ stage, oracle: { isOutcomeSet } }) => stage !== MARKET_STAGES.MARKET_CLOSED && !isOutcomeSet).length
-    const endingSoonMarketsAmount = markets.filter(({ eventDescription: { resolutionDate } }) => new Date(resolutionDate) - now < threeDayMSeconds).length
-    const newMarketsAmount = markets.filter(({ creationDate }) => now - new Date(creationDate) < threeDayMSeconds)
+    const openMarkets = markets.filter(market => !isMarketClosed(market) && !isMarketResolved(market))
+    const openMarketsAmount = openMarkets.length
+    const endingSoonMarketsAmount = openMarkets.filter(({ eventDescription: { resolutionDate } }) => new Date(resolutionDate) - now < threeDayMSeconds).length
+    const newMarketsAmount = openMarkets.filter(({ creationDate }) => now - new Date(creationDate) < threeDayMSeconds)
       .length
 
     return (

--- a/src/components/MarketMySharesForm/index.js
+++ b/src/components/MarketMySharesForm/index.js
@@ -24,6 +24,7 @@ import { getOutcomeName, weiToEth, normalizeScalarPoint } from 'utils/helpers'
 import { marketShape } from 'utils/shapes'
 
 import './marketMySharesForm.less'
+import { isMarketClosed, isMarketResolved } from '../../utils/helpers'
 
 class MarketMySharesForm extends Component {
   constructor(props) {
@@ -143,7 +144,7 @@ class MarketMySharesForm extends Component {
     const { marketShares, market } = this.props
     const { extendedSellId } = this.state
 
-    const resolved = market.oracle.isOutcomeSet || market.event.isWinningOutcomeSet
+    const resolvedOrClosed = isMarketClosed(market) || isMarketResolved(market)
 
     marketShares.forEach((share) => {
       const probability = calcLMSRMarginalPrice({
@@ -180,7 +181,7 @@ class MarketMySharesForm extends Component {
           <CurrencyName collateralToken={market.event.collateralToken} />
         </td>
         <td>
-          {!resolved && (
+          {!resolvedOrClosed && (
             <a
               href="javascript:void(0);"
               className="marketMyShares__sellButton"

--- a/src/config.json
+++ b/src/config.json
@@ -15,7 +15,8 @@
     "0x1df62f291b2e969fb0849d99d9ce41e2f137006e": "Account 10",
     "0x75e70a0204a9c2353f9de428cb87f38ead9f0160": "DenisUport",
     "0x65039084cc6f4773291a6ed7dcf5bc3a2e894ff3": "Denis Metamask",
-    "0x8b872b278cbdadd6a24751051d7d030bb7f35385": "GiacomoUport"
+    "0x8b872b278cbdadd6a24751051d7d030bb7f35385": "GiacomoUport",
+    "0x697321d5d8337450e50a404025dd4e6f8fa46eb7": "Mikhail Uport"
  },
   "productionWhitelist": {
     "0x75e70a0204a9c2353f9de428cb87f38ead9f0160": "Denis",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -3,7 +3,8 @@
 import { mapValues, startsWith, isArray, range } from 'lodash'
 import seedrandom from 'seedrandom'
 import Decimal from 'decimal.js'
-import { HEX_VALUE_REGEX, OUTCOME_TYPES } from 'utils/constants'
+import moment from 'moment'
+import { HEX_VALUE_REGEX, OUTCOME_TYPES, MARKET_STAGES } from 'utils/constants'
 import { WALLET_PROVIDER } from 'integrations/constants'
 import Web3 from 'web3'
 import Uport from 'integrations/uport'
@@ -25,6 +26,11 @@ export const hexWithoutPrefix = (value) => {
 export const add0xPrefix = value => (startsWith(value, '0x') ? value : `0x${value}`)
 
 export const hexWithPrefix = value => (HEX_VALUE_REGEX.test(value) ? add0xPrefix(value) : value)
+
+export const isMarketResolved = ({ oracle: { isOutcomeSet } }) => isOutcomeSet
+
+export const isMarketClosed = ({ stage, eventDescription: { resolutionDate } }) =>
+  stage !== MARKET_STAGES.MARKET_CLOSED && moment(resolutionDate).isBefore(moment())
 
 export const toEntity = (data, entityType, idKey = 'address') => {
   const { [idKey]: id, ...entityPayload } = mapValues(data, hexWithoutPrefix)


### PR DESCRIPTION
This PR includes: 
- Adds an additional check if the market resolution date has passed to not show the countdown
- Prevent trading on markets with passed resolution date
- add `isMarketClosed` and `isMarketResolved` helpers functions so we use the same way for checking market's status in all components
- refactor components to use this helper functions

**BEFORE:**
<img width="1677" alt="screen shot 2017-11-24 at 14 30 34" src="https://user-images.githubusercontent.com/16622558/33206584-2552dc4a-d124-11e7-8015-2278c34cec2c.png">

**AFTER:**
<img width="1680" alt="screen shot 2017-11-24 at 20 19 24" src="https://user-images.githubusercontent.com/16622558/33218191-07f73cf0-d155-11e7-9f7a-b8ee0df25bc2.png">

