### PR TITLE
Feature PM-141 Show winning outcome on scalar markets

### DIFF
--- a/src/components/OutcomeScalar/index.js
+++ b/src/components/OutcomeScalar/index.js
@@ -23,7 +23,6 @@ const OutcomeScalar = ({ market, opts: { showOnlyTrendingOutcome } }) => {
   const lowerBound = Decimal(market.event.lowerBound).div(10 ** decimals)
 
   const bounds = upperBound.sub(lowerBound)
-  console.log(bounds.toString())
   let value = Decimal(marginalPrice)
     .times(bounds)
     .add(lowerBound)


### PR DESCRIPTION
**BEFORE/AFTER:**
<img width="1680" alt="screen shot 2017-11-27 at 17 06 11" src="https://user-images.githubusercontent.com/16622558/33268095-4e9d6f66-d395-11e7-948a-e879f6432495.png">

This PR fixes adds showing winning outcome for scalar markets
