### PR TITLE
Feature PM-257 Show gas cost for Redeeming winnings

### DIFF
--- a/src/actions/blockchain.js
+++ b/src/actions/blockchain.js
@@ -9,6 +9,7 @@ import {
   calcScalarEventGasCost,
   calcCentralizedOracleGasCost,
   calcFundingGasCost,
+  calcRedeemWinningsGasCost,
   getGasPrice,
   getEtherTokens,
   getOlympiaTokensByAccount,
@@ -39,7 +40,7 @@ export const requestGasPrice = () => async (dispatch) => {
   dispatch(setGasPrice({ entityType: 'gasPrice', gasPrice }))
 }
 
-export const requestGasCost = contractType => async (dispatch) => {
+export const requestGasCost = (contractType, opts) => async (dispatch) => {
   if (contractType === GAS_COST.MARKET_CREATION) {
     calcMarketGasCost().then((gasCost) => {
       dispatch(setGasCost({ entityType: 'gasCosts', contractType, gasCost }))
@@ -66,6 +67,10 @@ export const requestGasCost = contractType => async (dispatch) => {
     })
   } else if (contractType === GAS_COST.FUNDING) {
     calcFundingGasCost().then((gasCost) => {
+      dispatch(setGasCost({ entityType: 'gasCosts', contractType, gasCost }))
+    })
+  } else if (contractType === GAS_COST.REDEEM_WINNINGS) {
+    calcRedeemWinningsGasCost(opts).then((gasCost) => {
       dispatch(setGasCost({ entityType: 'gasCosts', contractType, gasCost }))
     })
   }

--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -386,6 +386,28 @@ export const calcSellSharesGasCost = async () => {
 }
 
 /**
+ * Returns gas cost for redeem winnings
+ * @param {*object} opts options
+ * @param {*string} opts.eventAddress Address for the event
+ */
+
+export const calcRedeemWinningsGasCost = async (opts) => {
+  const { eventAddress } = opts
+  if (!eventAddress) {
+    return undefined
+  }
+
+  const gnosis = await getGnosisConnection()
+  const Event = await gnosis.contracts.Event.at(eventAddress)
+
+  const gasGost = await Event.redeemWinnings.estimateGas({
+    marketFactory: gnosis.contracts.StandardMarketFactory,
+    using: 'stats',
+  })
+  return gasGost
+}
+
+/**
  * Returns the current gas price
  */
 export const getGasPrice = async () => {

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -258,7 +258,7 @@ class MarketDetail extends Component {
                 <InteractionButton className="btn btn-primary" onClick={this.handleRedeemWinnings}>
                   Redeem Winnings
                 </InteractionButton>
-                <span className="redeemWinning__gasCost">Gas cost: {redeemWinningsTransactionGas}</span>
+                <span className="redeemWinning__gasCost">Gas cost: {redeemWinningsTransactionGas} ETH</span>
               </div>
             </div>
           )}

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -360,7 +360,7 @@ MarketDetail.propTypes = {
     id: PropTypes.string,
     view: PropTypes.string,
   }),
-  reqiestGasPrice: PropTypes.func,
+  requestGasPrice: PropTypes.func,
   marketShares: PropTypes.arrayOf(marketShareShape),
   defaultAccount: PropTypes.string,
   market: marketShape,

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -24,7 +24,7 @@ import expandableViews, { EXPAND_MY_SHARES } from './ExpandableViews'
 
 import './marketDetail.less'
 import { weiToEth, isMarketClosed, isMarketResolved } from '../../utils/helpers'
-import { marketShareShape } from '../../utils/shapes'
+import { marketShareShape, gasCostsShape } from '../../utils/shapes'
 
 const ONE_WEEK_IN_HOURS = 168
 
@@ -71,6 +71,7 @@ class MarketDetail extends Component {
     this.props
       .fetchMarket()
       .then(() => {
+        this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
         this.props.fetchMarketTrades(this.props.market)
         if (this.props.defaultAccount) {
           this.props.fetchMarketShares(this.props.defaultAccount)
@@ -96,6 +97,7 @@ class MarketDetail extends Component {
     if (this.props.defaultAccount && this.props.params.id) {
       this.props.fetchMarketParticipantTrades(this.props.params.id, this.props.defaultAccount)
     }
+    this.props.requestGasPrice()
   }
 
   @autobind
@@ -180,8 +182,7 @@ class MarketDetail extends Component {
       .utc(market.eventDescription.resolutionDate)
       .local()
       .diff(moment(), 'hours')
-    const { marketShares } = this.props
-    const resolutionDateNotPassed = moment(market.eventDescription.resolutionDate).isAfter(moment())
+    const { marketShares, gasCosts: { redeemWinnings: redeemWinningsGasCost }, gasPrice } = this.props
 
     const marketClosed = isMarketClosed(market)
     const marketResolved = isMarketResolved(market)
@@ -189,6 +190,11 @@ class MarketDetail extends Component {
     const marketClosedOrFinished = marketClosed || marketResolved
     const marketStatus = marketResolved ? 'resolved.' : 'closed.'
     const showCountdown = !marketClosedOrFinished && timeToResolution < ONE_WEEK_IN_HOURS
+    const redeemWinningsTransactionGas = gasPrice
+      .mul(redeemWinningsGasCost || 0)
+      .div(1e18)
+      .toDP(5, 1)
+      .toString()
 
     const winnings = marketShares.reduce((sum, share) => {
       const shareWinnings = weiToEth(calcLMSRProfit({
@@ -252,6 +258,7 @@ class MarketDetail extends Component {
                 <InteractionButton className="btn btn-primary" onClick={this.handleRedeemWinnings}>
                   Redeem Winnings
                 </InteractionButton>
+                <span className="redeemWinning__gasCost">Gas cost: {redeemWinningsTransactionGas}</span>
               </div>
             </div>
           )}
@@ -353,6 +360,7 @@ MarketDetail.propTypes = {
     id: PropTypes.string,
     view: PropTypes.string,
   }),
+  reqiestGasPrice: PropTypes.func,
   marketShares: PropTypes.arrayOf(marketShareShape),
   defaultAccount: PropTypes.string,
   market: marketShape,
@@ -370,6 +378,8 @@ MarketDetail.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }),
+  gasCosts: gasCostsShape,
+  gasPrice: PropTypes.instanceOf(Decimal),
 }
 
 export default MarketDetail

--- a/src/components/MarketDetail/marketDetail.less
+++ b/src/components/MarketDetail/marketDetail.less
@@ -192,6 +192,7 @@
   }
 
   &__action {
+    text-align: center;
     .btn {
       padding: 10px;
       margin-top: 30px;
@@ -200,6 +201,12 @@
       text-align: center;
       line-height: 1;
     }
+  }
+
+  &__gasCost {
+    margin-top: 5px;
+    display: inline-block;
+    color: @font-color-muted;
   }
 
   &::after {

--- a/src/containers/MarketDetailPage/index.js
+++ b/src/containers/MarketDetailPage/index.js
@@ -74,7 +74,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   changeUrl: url => dispatch(replace(url)),
   redeemWinnings: market => dispatch(redeemWinnings(market)),
   withdrawFees: market => dispatch(withdrawFees(market)),
-  requestGasCost: contractType => dispatch(requestGasCost(contractType)),
+  requestGasCost: (contractType, opts) => dispatch(requestGasCost(contractType, opts)),
   requestGasPrice: () => dispatch(requestGasPrice()),
   closeMarket: market => dispatch(closeMarket(market)),
 })

--- a/src/utils/shapes.js
+++ b/src/utils/shapes.js
@@ -22,7 +22,7 @@ export const marketShareShape = PropTypes.shape({
   event: PropTypes.string,
   eventDescription: eventDescriptionShape,
   id: PropTypes.string,
-  marginalPrice: PropTypes.string,
+  marginalPrice: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   outcomeToken: outcomeTokenShape,
   owner: PropTypes.string,
 })
@@ -58,4 +58,17 @@ export const transactionShape = PropTypes.shape({
   endTime: PropTypes.string,
   completed: PropTypes.bool,
   completionStatus: PropTypes.oneOf(Object.values(TRANSACTION_COMPLETE_STATUS)),
+})
+
+export const gasCostsShape = PropTypes.shape({
+  redeemWinnings: PropTypes.number,
+  market: PropTypes.number,
+  buyShares: PropTypes.number,
+  sellShares: PropTypes.number,
+  resolveOracle: PropTypes.number,
+  withdrawFees: PropTypes.number,
+  categoricalEvent: PropTypes.number,
+  scalarEvent: PropTypes.number,
+  centralizedOracle: PropTypes.number,
+  funding: PropTypes.number,
 })


### PR DESCRIPTION
This PR adds showing of gas cost for redeem winnings transaction

**BEFORE:** 
<img width="1127" alt="screen shot 2017-11-28 at 15 19 25" src="https://user-images.githubusercontent.com/16622558/33317083-960bb9c4-d44f-11e7-9d22-94d76fa50775.png">

**AFTER:**
<img width="1680" alt="screen shot 2017-11-28 at 15 13 52" src="https://user-images.githubusercontent.com/16622558/33317099-a197edbc-d44f-11e7-93a6-03c97b91d55d.png">

