### PR TITLE
PM-256 QRCode and Notifications uPort solution

### DIFF
--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -1,7 +1,7 @@
-import { decodeToken } from 'jsontokens'
 import { Connect, SimpleSigner } from 'uport-connect'
 
-export const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
+const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
+const LOGIN_TEXT = 'Log into <b>Gnosis Olympia</b>'
 
 const uport = new Connect('Gnosis', {
   clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
@@ -9,24 +9,30 @@ const uport = new Connect('Gnosis', {
   signer: SimpleSigner('80b6d12233a5dc01ea46ebf773919f2418b44412c6318d0f2b676b3a1c6b634a'),
 })
 
-const loginText = 'Log into <b>Gnosis Olympia</b>'
+const getCredentialsFromLocalStorage = () => {
+  const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
 
-export default uport
+  return cred ? JSON.parse(cred) : cred
+}
 
-export const requestCredentials = async () => {
-  try {
-    if (document && uport.firstReq) {
-      // https://github.com/uport-project/uport-connect/blob/develop/src/util/qrdisplay.js#L41
-      // https://github.com/uport-project/uport-connect/blob/develop/src/util/qrdisplay.js#L72
+const modifyUportLoginModal = (firstReq) => {
+  if (!document && !firstReq) {
+    return
+  }
 
-      setTimeout(() => {
-        const loginTextParagraph = document.getElementById('uport-qr-text')
-        if (loginTextParagraph) {
-          loginTextParagraph.innerHTML = loginText
-        }
-      }, 100)
+  // https://github.com/uport-project/uport-connect/blob/develop/src/util/qrdisplay.js#L41
+  // https://github.com/uport-project/uport-connect/blob/develop/src/util/qrdisplay.js#L72
+  setTimeout(() => {
+    const loginTextParagraph = document.getElementById('uport-qr-text')
+    if (loginTextParagraph) {
+      loginTextParagraph.innerHTML = LOGIN_TEXT
     }
+  }, 100)
+}
 
+const requestCredentials = async () => {
+  try {
+    modifyUportLoginModal(uport.firstReq)
     const cred = await uport.requestCredentials({ notifications: true })
     localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
   } catch (err) {
@@ -34,27 +40,10 @@ export const requestCredentials = async () => {
   }
 }
 
-export const getCredentialsFromLocalStorage = () => {
-  const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
+const initUportConnector = async (useNotifications) => {
+  const provider = useNotifications ? await import('./uportNotifications') : await import('./uportQr')
 
-  return cred ? JSON.parse(cred) : cred
+  return provider.default(uport, requestCredentials, getCredentialsFromLocalStorage)
 }
 
-export const hasValidCredential = () => {
-  const cred = getCredentialsFromLocalStorage()
-  if (cred === null) {
-    return false
-  }
-
-  const pushToken = decodeToken(cred.pushToken)
-  if (!pushToken) {
-    return false
-  }
-
-  const expiration = pushToken.payload.exp // When the uPort credential will expire
-  const oneDay = 24 * 60 * 6 // one day in seconds
-  const now = new Date() / 1000 // in seconds
-  const isValid = expiration - oneDay > now
-
-  return isValid
-}
+export default initUportConnector

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -30,20 +30,22 @@ const modifyUportLoginModal = (firstReq) => {
   }, 100)
 }
 
-const requestCredentials = async () => {
+const requestCredentials = notifications => async () => {
   try {
     modifyUportLoginModal(uport.firstReq)
-    const cred = await uport.requestCredentials({ notifications: true })
+    const cred = await uport.requestCredentials({ notifications })
     localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
+    return cred
   } catch (err) {
     localStorage.removeItem(UPORT_OLYMPIA_KEY)
+    return null
   }
 }
 
 const initUportConnector = async (useNotifications) => {
   const provider = useNotifications ? await import('./uportNotifications') : await import('./uportQr')
 
-  return provider.default(uport, requestCredentials, getCredentialsFromLocalStorage)
+  return provider.default(uport, requestCredentials(useNotifications), getCredentialsFromLocalStorage)
 }
 
 export default initUportConnector

--- a/src/integrations/uport/uportNotifications.js
+++ b/src/integrations/uport/uportNotifications.js
@@ -1,0 +1,44 @@
+import { decodeToken } from 'jsontokens'
+
+const isValid = (cred) => {
+  if (cred === null) {
+    return false
+  }
+
+  const pushToken = decodeToken(cred.pushToken)
+  if (!pushToken) {
+    return false
+  }
+
+  const expiration = pushToken.payload.exp // When the uPort credential will expire
+  const oneDay = 24 * 60 * 6 // one day in seconds
+  const now = new Date() / 1000 // in seconds
+  const valid = expiration - oneDay > now
+
+  return valid
+}
+
+const assignSessionProps = (cred, uport) => {
+  /* eslint-disable */
+  uport.address = cred.address
+  uport.pushToken = cred.pushToken
+  uport.publicEncKey = cred.publicEncKey
+  /* eslint-enable */
+}
+
+const init = async (uport, requestCredentials, getCredential) => {
+  let credential = getCredential()
+  if (!isValid(credential)) {
+    await requestCredentials()
+  }
+
+  credential = getCredential()
+
+  if (credential) {
+    assignSessionProps(uport, credential)
+  }
+
+  return uport
+}
+
+export default init

--- a/src/integrations/uport/uportNotifications.js
+++ b/src/integrations/uport/uportNotifications.js
@@ -29,10 +29,8 @@ const assignSessionProps = (cred, uport) => {
 const init = async (uport, requestCredentials, getCredential) => {
   let credential = getCredential()
   if (!isValid(credential)) {
-    await requestCredentials()
+    credential = await requestCredentials()
   }
-
-  credential = getCredential()
 
   if (credential) {
     assignSessionProps(uport, credential)

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -1,0 +1,23 @@
+const isValid = cred => !!cred
+
+const assignSessionProps = (cred, uport) => {
+  // eslint-disable-next-line
+  uport.address = cred.address
+}
+
+const init = async (uport, requestCredentials, getCredential) => {
+  let credential = getCredential()
+  if (!isValid(credential)) {
+    await requestCredentials()
+  }
+
+  credential = getCredential()
+
+  if (credential) {
+    assignSessionProps(uport, credential)
+  }
+
+  return uport
+}
+
+export default init

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -8,10 +8,8 @@ const assignSessionProps = (cred, uport) => {
 const init = async (uport, requestCredentials, getCredential) => {
   let credential = getCredential()
   if (!isValid(credential)) {
-    await requestCredentials()
+    credential = await requestCredentials()
   }
-
-  credential = getCredential()
 
   if (credential) {
     assignSessionProps(uport, credential)


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR includes as a static property the uport's behaviour. Now we can switch from using QRCode to Push Notifications and vice-versa. 
I have followed uport's team instructions and for implementing the session management we set in the ```uport```object the following local-stored props:

_PushNotifications_
```
  uport.address = cred.address
  uport.pushToken = cred.pushToken
  uport.publicEncKey = cred.publicEncKey
```
_QR Code scan_
```
  uport.address = cred.address
```

**DevNotes**
After a conversation with UPort's team, they recommend me to set the credential's address in both ways, that broke my initial implementation. Right now, after a couple of refactors, despite the "repeated" code on the default's method on ```uportNotifications and uportQr```, I consider is the best approach we can follow. The uport provider is simpler and easier to understand, the ```connector.js``` class only contains methods about how to connect with uport and deal with storage solutions.

**PM Notes**
Tested using both approaches and it works fine for me. The only thing that maybe is not right, if the app is working on QRCode way, and you refresh the browser, you have to do an extra-scan for log into the app. I have followed if you 