### PR TITLE
Feature  PM-268  set uport firstreq prop session management

### DIFF
--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -35,6 +35,7 @@ const requestCredentials = useNotifications => async () => {
     modifyUportLoginModal(uport.firstReq)
     const cred = await uport.requestCredentials({ notifications: useNotifications })
     localStorage.setItem(UPORT_OLYMPIA_KEY, JSON.stringify(cred))
+
     return cred
   } catch (err) {
     localStorage.removeItem(UPORT_OLYMPIA_KEY)

--- a/src/integrations/uport/uportNotifications.js
+++ b/src/integrations/uport/uportNotifications.js
@@ -18,7 +18,7 @@ const isValid = (cred) => {
   return valid
 }
 
-const assignSessionProps = (cred, uport) => {
+const assignSessionProps = (uport, cred) => {
   /* eslint-disable */
   uport.address = cred.address
   uport.pushToken = cred.pushToken

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -3,6 +3,8 @@ const isValid = cred => !!cred
 const assignSessionProps = (cred, uport) => {
   // eslint-disable-next-line
   uport.address = cred.address
+  // eslint-disable-next-line
+  uport.firstReq = false
 }
 
 const init = async (uport, requestCredentials, getCredential) => {

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -1,6 +1,6 @@
 const isValid = cred => !!cred
 
-const assignSessionProps = (cred, uport) => {
+const assignSessionProps = (uport, cred) => {
   // eslint-disable-next-line
   uport.address = cred.address
   // eslint-disable-next-line

--- a/src/routes/scoreboard/store/actions/fetchOlympiaUserData.js
+++ b/src/routes/scoreboard/store/actions/fetchOlympiaUserData.js
@@ -1,14 +1,15 @@
 import { restFetch } from 'utils/helpers'
 import addUsers from './addUsers'
 
-const url = 'https://gnosisdb-olympia.gnosis.pm/api/scoreboard/'
+const API_URL = `${process.env.GNOSISDB_URL}/api`
+const url = `${API_URL}/scoreboard/`
 
 export default account => dispatch =>
-    restFetch(url + account)
-        .then((response) => {
-            if (!response) {
-                dispatch(addUsers([]))
-            }
+  restFetch(url + account)
+    .then((response) => {
+      if (!response) {
+        dispatch(addUsers([]))
+      }
 
-            dispatch(addUsers([response]))
-        })
+      dispatch(addUsers([response]))
+    })

--- a/src/routes/scoreboard/store/actions/fetchOlympiaUsers.js
+++ b/src/routes/scoreboard/store/actions/fetchOlympiaUsers.js
@@ -1,14 +1,15 @@
 import { restFetch } from 'utils/helpers'
 import addUsers from './addUsers'
 
-const url = 'https://gnosisdb-olympia.gnosis.pm/api/scoreboard/'
+const API_URL = `${process.env.GNOSISDB_URL}/api`
+const url = `${API_URL}/scoreboard/`
 
 export default () => dispatch =>
-    restFetch(url)
-        .then((response) => {
-            if (!response) {
-                dispatch(addUsers([]))
-            }
+  restFetch(url)
+    .then((response) => {
+      if (!response) {
+        dispatch(addUsers([]))
+      }
 
-            dispatch(addUsers(response.results))
-        })
+      dispatch(addUsers(response.results))
+    })


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR includes a couple of fixes for improving the uport' session management. Basically calling the method for assigning session props correctly, also in the QRCode mode I assign firstReq to false in order to avoid an extra scan

