### PR TITLE
PM-300: Selected/Current Trade in MarketDetail styling fixes

### DIFF
--- a/src/components/ScalarSlider/index.js
+++ b/src/components/ScalarSlider/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Decimal from 'decimal.js'
 import cn from 'classnames'
 
-import DecimalValue from 'components/DecimalValue'
+import { decimalToText } from 'components/DecimalValue'
 
 import './scalarSlider.less'
 
@@ -13,17 +13,20 @@ const ScalarSlider = ({
   const bigLowerBound = new Decimal(lowerBound)
   const bigUpperBound = new Decimal(upperBound)
 
+  // for the value we show atleast 2 decimalplaces, so users can see a change when they enter an investment
+  const displayDecimals = Math.max(decimals, 2)
+
   // current value
   const bounds = bigUpperBound.sub(bigLowerBound).div(10 ** decimals)
 
   const value = new Decimal(marginalPriceCurrent)
     .mul(bounds.toString())
-    .add(bigLowerBound.div(10 ** decimals).toString())
+    .add(bigLowerBound.div(10 ** displayDecimals).toString())
   const percentage = new Decimal(marginalPriceCurrent).mul(100)
 
   const selectedValue = new Decimal(marginalPriceSelected)
     .mul(bounds.toString())
-    .add(bigLowerBound.div(10 ** decimals).toString())
+    .add(bigLowerBound.div(10 ** displayDecimals).toString())
   const selectedPercentage = new Decimal(marginalPriceSelected).mul(100)
 
   const currentValueSliderStyle = { left: `${percentage.toFixed(4)}%` }
@@ -33,31 +36,31 @@ const ScalarSlider = ({
     <div className="scalarSlider">
       <div className="scalarSlider__inner">
         <div className="scalarSlider__lowerBound">
-          {bigLowerBound.div(10 ** decimals).toFixed(0)} {unit}
+          <div className="scalarSlider__lowerBoundValue">{`${bigLowerBound.div(10 ** decimals).toFixed(0)} ${unit}`}</div>
           <div className="scalarSlider__lowerBoundLabel">Lower Bound</div>
         </div>
         <div className="scalarSlider__bar" title="Please enter a value on the right!">
-          <div className="scalarSlider__handle" style={currentValueSliderStyle}>
+          <div className="scalarSlider__handle scalarSlider__handle--current" style={currentValueSliderStyle}>
             <div className="scalarSlider__handleText">
-              <div className="scalarSlider__handleTextLabel">Current Bet</div>
-              <DecimalValue value={value} decimals={decimals} /> {unit}
+              <div className="scalarSlider__handleTextLabel">Current Trade</div>
+              <div className="scalarSlider__handleTextValue">{`${decimalToText(value)} ${unit}`}</div>
             </div>
           </div>
           <div
-            className={cn('scalarSlider__handle scalarSlider__handle--below', {
+            className={cn('scalarSlider__handle scalarSlider__handle--selected scalarSlider__handle--below', {
               'scalarSlider__handle--below--pinRight': selectedPercentage.gt(75),
               'scalarSlider__handle--below--pinLeft': selectedPercentage.lt(25),
             })}
             style={selectedValueSliderStyle}
           >
             <div className="scalarSlider__handleText">
-              <div className="scalarSlider__handleTextLabel">Selected Bet</div>
-              <DecimalValue value={selectedValue} decimals={decimals} /> {unit}
+              <div className="scalarSlider__handleTextLabel">Selected Trade</div>
+              <div className="scalarSlider__handleTextValue">{`${decimalToText(selectedValue)} ${unit}`}</div>
             </div>
           </div>
         </div>
         <div className="scalarSlider__upperBound">
-          {bigUpperBound.div(10 ** decimals).toFixed(0)} {unit}
+          <div className="scalarSlider__upperBoundValue">{`${bigUpperBound.div(10 ** decimals).toFixed(0)} ${unit}`}</div>
           <div className="scalarSlider__upperBoundLabel">Upper Bound</div>
         </div>
       </div>

--- a/src/components/ScalarSlider/scalarSlider.less
+++ b/src/components/ScalarSlider/scalarSlider.less
@@ -2,7 +2,9 @@
 
 @slider-stroke-size: 2px;
 @slider-handle-size: 16px;
-@slider-handle-text-width: 200px;
+@slider-handle-text-width: 150px;
+
+@scalarSliderBackground: #d6d8d8;
 
 .scalarSlider {
   width: 100%;
@@ -26,7 +28,7 @@
       content: '';
       position: absolute;
       width: 100%;
-      border: @slider-stroke-size solid @font-color-dark;
+      border: @slider-stroke-size solid @scalarSliderBackground;
       border-radius: 20px;
       height: 0;
     }
@@ -36,6 +38,7 @@
     position: absolute;
     height: 100%;
     cursor: not-allowed;
+    transition: left 1s ease-in-out;
 
     &::after {
       content: '';
@@ -49,9 +52,32 @@
       z-index: 2;
     }
 
-    &--below {
+    &--selected {
+      &::after {
+        background-color: @active-highlight;
+      }
+
       .scalarSlider__handleText {
-        top: 30px;
+        top: 50px;
+        padding: 5px 4px;
+        background-color: @active-highlight;
+        color: white;
+
+        &Label {
+          color: white;
+        }
+
+        &::before {
+          content: '';
+          position: absolute;
+          top: -15px;
+          height: 15px;
+          width: 20px;
+          margin-left: -10px;
+          border-left: 10px solid transparent;
+          border-right: 10px solid transparent;
+          border-bottom: 10px solid #00a6c4;
+        }
       }
 
       &--pinRight {
@@ -71,7 +97,7 @@
 
     &Text {
       position: relative;
-      top: -20px;
+      top: -30px;
       text-align: center;
       left: (@slider-handle-size / 2);
       width: @slider-handle-text-width;
@@ -84,6 +110,14 @@
       font-size: 12px;
       color: @font-color-dark;
       white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    &TextValue {
+      white-space: nowrap;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
@@ -105,6 +139,14 @@
       font-size: 12px;
       color: @font-color-dark;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &Value {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }


### PR DESCRIPTION
Now looks like this:

![image](https://user-images.githubusercontent.com/969493/33671081-f1808926-daa6-11e7-972f-cf2585155fbb.png)

Text overflowing is also fixed, which happened before for really long outcome unit names.
Minimum amount of Decimals added for the displayed value, so even if the value has no significant decimalplaces, it will still show atleast two so the user knows that something happened.