### PR TITLE
PM-344: Cancelling the login screen

### DIFF
--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -15,6 +15,8 @@ const getCredentialsFromLocalStorage = () => {
   return cred ? JSON.parse(cred) : cred
 }
 
+export const isUserConnected = uportInstance => !!uportInstance.address
+
 const modifyUportLoginModal = (firstReq) => {
   if (!document && !firstReq) {
     return

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -39,13 +39,17 @@ class Uport extends BaseIntegration {
     })
 
     this.uport = await initUportConnector(Uport.USE_NOTIFICATIONS)
-
     this.web3 = await this.uport.getWeb3()
     this.provider = await this.uport.getProvider()
     this.network = await this.getNetwork()
     this.networkId = await this.getNetworkId()
-    this.account = opts.uportDefaultAccount || (await this.getAccount())
-
+    this.account = null
+    console.log(this.uport)
+    const uPortIsSet = this.uport.cliendId !== null
+    if (uPortIsSet) {
+      this.account = opts.uportDefaultAccount || (await this.getAccount())
+    }
+    console.log(this.account)
     return this.runProviderUpdate(this, {
       available: true,
       network: this.network,

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -1,4 +1,5 @@
 import { getOlympiaTokensByAccount } from 'api'
+import { setConnectionStatus } from 'actions/blockchain'
 import { WALLET_PROVIDER } from 'integrations/constants'
 import BaseIntegration from 'integrations/baseIntegration'
 import { fetchOlympiaUserData } from 'routes/scoreboard/store/actions'
@@ -44,12 +45,12 @@ class Uport extends BaseIntegration {
     this.network = await this.getNetwork()
     this.networkId = await this.getNetworkId()
     this.account = null
-    console.log(this.uport)
-    const uPortIsSet = this.uport.cliendId !== null
+
+    const uPortIsSet = this.uport.address !== null
     if (uPortIsSet) {
       this.account = opts.uportDefaultAccount || (await this.getAccount())
     }
-    console.log(this.account)
+
     return this.runProviderUpdate(this, {
       available: true,
       network: this.network,
@@ -58,6 +59,7 @@ class Uport extends BaseIntegration {
     })
       .then(async () => {
         if (!this.account) {
+          opts.dispatch(setConnectionStatus({ connected: false }))
           return
         }
         await opts.initGnosis()

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -4,7 +4,7 @@ import { WALLET_PROVIDER } from 'integrations/constants'
 import BaseIntegration from 'integrations/baseIntegration'
 import { fetchOlympiaUserData } from 'routes/scoreboard/store/actions'
 import { weiToEth } from 'utils/helpers'
-import initUportConnector from './connector'
+import initUportConnector, { isUserConnected } from './connector'
 
 class Uport extends BaseIntegration {
   static providerName = WALLET_PROVIDER.UPORT
@@ -46,8 +46,8 @@ class Uport extends BaseIntegration {
     this.networkId = await this.getNetworkId()
     this.account = null
 
-    const uPortIsSet = this.uport.address !== null
-    if (uPortIsSet) {
+    const userConnected = isUserConnected(this.uport)
+    if (userConnected) {
       this.account = opts.uportDefaultAccount || (await this.getAccount())
     }
 
@@ -58,7 +58,7 @@ class Uport extends BaseIntegration {
       account: this.account,
     })
       .then(async () => {
-        if (!this.account) {
+        if (!userConnected) {
           opts.dispatch(setConnectionStatus({ connected: false }))
           return
         }

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -10,6 +10,7 @@ const assignSessionProps = (uport, cred) => {
 const init = async (uport, requestCredentials, getCredential) => {
   let credential = getCredential()
   if (!isValid(credential)) {
+    uport.firstReq = true
     credential = await requestCredentials()
   }
 

--- a/src/selectors/blockchain.js
+++ b/src/selectors/blockchain.js
@@ -148,5 +148,3 @@ export const initializedAllProviders = (state) => {
 
   return allProvidersLoaded
 }
-
-// export const getUportAvailability = state => get(state, )

--- a/src/selectors/blockchain.js
+++ b/src/selectors/blockchain.js
@@ -148,3 +148,5 @@ export const initializedAllProviders = (state) => {
 
   return allProvidersLoaded
 }
+
+// export const getUportAvailability = state => get(state, )


### PR DESCRIPTION
This PR:
- Adds a check before calling `this.getAccount()` so we know if uPort connection is initialized and not show QR code modal second time
- Set `uPort.firstReq` to true before showing login modal, so user can see download links and not only QR code

**BEFORE:**
If you click cancel on `Login` modal, QR code will show and if you close it, the website is stuck on `Connecting...`

**AFTER:**
Cancelling `Login` modal leads to the interface.
