### PR TITLE
PM-339: "Sell" shows even if market is closed

### DIFF
--- a/src/components/ScalarSlider/index.js
+++ b/src/components/ScalarSlider/index.js
@@ -10,8 +10,8 @@ import './scalarSlider.less'
 const ScalarSlider = ({
   lowerBound, upperBound, unit, marginalPriceCurrent, marginalPriceSelected, decimals,
 }) => {
-  const bigLowerBound = Decimal(lowerBound)
-  const bigUpperBound = Decimal(upperBound)
+  const bigLowerBound = new Decimal(lowerBound)
+  const bigUpperBound = new Decimal(upperBound)
 
   // for the value we show atleast 2 decimalplaces, so users can see a change when they enter an investment
   const displayDecimals = Math.max(decimals, 2)
@@ -19,15 +19,15 @@ const ScalarSlider = ({
   // current value
   const bounds = bigUpperBound.sub(bigLowerBound).div(10 ** decimals)
 
-  const value = Decimal(marginalPriceCurrent)
+  const value = new Decimal(marginalPriceCurrent)
     .mul(bounds.toString())
-    .add(bigLowerBound.div(10 ** decimals).toString())
-  const percentage = Decimal(marginalPriceCurrent).mul(100)
+    .add(bigLowerBound.div(10 ** displayDecimals).toString())
+  const percentage = new Decimal(marginalPriceCurrent).mul(100)
 
-  const selectedValue = Decimal(marginalPriceSelected)
+  const selectedValue = new Decimal(marginalPriceSelected)
     .mul(bounds.toString())
-    .add(bigLowerBound.div(10 ** decimals).toString())
-  const selectedPercentage = Decimal(marginalPriceSelected).mul(100)
+    .add(bigLowerBound.div(10 ** displayDecimals).toString())
+  const selectedPercentage = new Decimal(marginalPriceSelected).mul(100)
 
   const currentValueSliderStyle = { left: `${percentage.toFixed(4)}%` }
   const selectedValueSliderStyle = { left: `${selectedPercentage.toFixed(4)}%` }
@@ -43,7 +43,7 @@ const ScalarSlider = ({
           <div className="scalarSlider__handle scalarSlider__handle--current" style={currentValueSliderStyle}>
             <div className="scalarSlider__handleText">
               <div className="scalarSlider__handleTextLabel">Predicted Outcome</div>
-              <div className="scalarSlider__handleTextValue">{`${decimalToText(value.toFixed(displayDecimals))} ${unit}`}</div>
+              <div className="scalarSlider__handleTextValue">{`${decimalToText(value)} ${unit}`}</div>
             </div>
           </div>
           <div
@@ -55,7 +55,7 @@ const ScalarSlider = ({
           >
             <div className="scalarSlider__handleText">
               <div className="scalarSlider__handleTextLabel">Selected Trade</div>
-              <div className="scalarSlider__handleTextValue">{`${decimalToText(selectedValue.toFixed(displayDecimals))} ${unit}`}</div>
+              <div className="scalarSlider__handleTextValue">{`${decimalToText(selectedValue)} ${unit}`}</div>
             </div>
           </div>
         </div>

--- a/src/config.json
+++ b/src/config.json
@@ -17,7 +17,7 @@
     "0x65039084cc6f4773291a6ed7dcf5bc3a2e894ff3": "Denis Metamask",
     "0x8b872b278cbdadd6a24751051d7d030bb7f35385": "GiacomoUport",
     "0x63c6c8f42a623c3c82a1d347548ef52200eae31b": "Mikhail Uport",
-    "0x948429537f335bbcfc0c7aa348322db5fa1919be": "OlympiaAdmin"
+    "0xcab5bb0408c48780d38c452be20e30da1a10e656": "OlympiaAdmin"
  },
   "productionWhitelist": {
     "0xcab5bb0408c48780d38c452be20e30da1a10e656": "OlympiaAdmin"

--- a/src/selectors/market.js
+++ b/src/selectors/market.js
@@ -1,7 +1,6 @@
 import { values } from 'lodash'
 import Decimal from 'decimal.js'
-import { isMarketResolved, isMarketClosed, hexWithPrefix } from 'utils/helpers'
-import { LOWEST_DISPLAYED_VALUE } from 'utils/constants'
+import { isMarketResolved, isMarketClosed } from 'utils/helpers'
 
 import { entitySelector } from './entities'
 import { getEventByAddress } from './event'

--- a/src/selectors/marketShares.js
+++ b/src/selectors/marketShares.js
@@ -61,31 +61,27 @@ const eventMarketSelector = marketAddress => (state) => {
   return { [eventAddress]: market }
 }
 
-const eventSharesSelector = createSelector(
-  getCurrentAccount,
-  getShares,
-  (account, shares) => {
-    const eventShares = {}
+const eventSharesSelector = createSelector(getCurrentAccount, getShares, (account, shares) => {
+  const eventShares = {}
 
-    Object.keys(shares).forEach((shareId) => {
-      if (add0xPrefix(shares[shareId].owner) !== add0xPrefix(account)) {
-        return
-      }
+  Object.keys(shares).forEach((shareId) => {
+    if (add0xPrefix(shares[shareId].owner) !== add0xPrefix(account)) {
+      return
+    }
 
-      const eventAddress = add0xPrefix(shares[shareId].event)
+    const eventAddress = add0xPrefix(shares[shareId].event)
 
-      if (!eventShares[eventAddress]) {
-        eventShares[eventAddress] = []
-      }
-      eventShares[eventAddress].push({
-        ...shares[shareId],
-        id: shareId,
-      })
+    if (!eventShares[eventAddress]) {
+      eventShares[eventAddress] = []
+    }
+    eventShares[eventAddress].push({
+      ...shares[shareId],
+      id: shareId,
     })
+  })
 
-    return eventShares
-  },
-)
+  return eventShares
+})
 
 const enhanceShares = (oracles, events, eventDescriptions, eventMarkets, eventShares, account) => {
   const enhancedShares = {}
@@ -108,7 +104,8 @@ const enhanceShares = (oracles, events, eventDescriptions, eventMarkets, eventSh
       }
 
       const isShareEventResolved = oracle.isOutcomeSet && event.isWinningOutcomeSet
-      const isShareMarketClosed = market.stage === MARKET_STAGES.MARKET_CLOSED || moment(resolutionDate).isBefore(moment().utc())
+      const isShareMarketClosed =
+        market.stage === MARKET_STAGES.MARKET_CLOSED || moment(resolutionDate).isBefore(moment().utc())
       const shareWinning = isShareEventResolved ? calcShareWinnings(share, market, event, account) : '0'
 
       if (isShareEventResolved && Decimal(shareWinning).eq(0)) {
@@ -155,12 +152,13 @@ export const getAccountShares = createSelector(
   enhanceShares,
 )
 
-export const getMarketShares = marketAddress => createSelector(
-  getOracles,
-  getEvents,
-  getEventDescriptions,
-  eventMarketSelector(marketAddress),
-  eventSharesSelector,
-  getCurrentAccount,
-  enhanceShares,
-)
+export const getMarketShares = marketAddress =>
+  createSelector(
+    getOracles,
+    getEvents,
+    getEventDescriptions,
+    eventMarketSelector(marketAddress),
+    eventSharesSelector,
+    getCurrentAccount,
+    enhanceShares,
+  )


### PR DESCRIPTION
This PR:
- Adds `isClosed` param to share
- Now share is sellable only if market is not closed or resolved

**BEFORE:**
You can see `SELL` on a closed market in `My holdings` widget in the dashboard

**AFTER:**
You can't see `SELL` on a closed market.