### PR TITLE
PM-364: Sort market shares to make sure they are in right order

### DIFF
--- a/src/components/MarketMySharesForm/index.js
+++ b/src/components/MarketMySharesForm/index.js
@@ -150,9 +150,16 @@ class MarketMySharesForm extends Component {
     const { marketShares, market } = this.props
     const { extendedSellId } = this.state
 
+    const marketSharesSorted = Object.keys(marketShares).sort((a, b) => {
+      const { outcomeToken: { index: firstOutcomeIndex } } = marketShares[a]
+      const { outcomeToken: { index: secondOutcomeIndex } } = marketShares[b]
+
+      return firstOutcomeIndex - secondOutcomeIndex
+    })
+
     const resolvedOrClosed = isMarketClosed(market) || isMarketResolved(market)
 
-    Object.keys(marketShares).forEach((shareId) => {
+    marketSharesSorted.forEach((shareId) => {
       const share = marketShares[shareId]
       const colorScheme = share.event.type === OUTCOME_TYPES.SCALAR ? COLOR_SCHEME_SCALAR : COLOR_SCHEME_DEFAULT
       const outcomeColorStyle = { backgroundColor: colorScheme[share.outcomeToken.index] }
@@ -182,7 +189,7 @@ class MarketMySharesForm extends Component {
             </a>
           )}
         </td>
-      </tr>)
+                     </tr>)
 
       if (share.id === extendedSellId) {
         tableRows.push(<tr className="marketMyShares__sellView" key={`${share.id}__sell`}>

--- a/src/components/MarketMySharesForm/index.js
+++ b/src/components/MarketMySharesForm/index.js
@@ -150,16 +150,9 @@ class MarketMySharesForm extends Component {
     const { marketShares, market } = this.props
     const { extendedSellId } = this.state
 
-    const marketSharesSorted = Object.keys(marketShares).sort((a, b) => {
-      const { outcomeToken: { index: firstOutcomeIndex } } = marketShares[a]
-      const { outcomeToken: { index: secondOutcomeIndex } } = marketShares[b]
-
-      return firstOutcomeIndex - secondOutcomeIndex
-    })
-
     const resolvedOrClosed = isMarketClosed(market) || isMarketResolved(market)
 
-    marketSharesSorted.forEach((shareId) => {
+    Object.keys(marketShares).forEach((shareId) => {
       const share = marketShares[shareId]
       const colorScheme = share.event.type === OUTCOME_TYPES.SCALAR ? COLOR_SCHEME_SCALAR : COLOR_SCHEME_DEFAULT
       const outcomeColorStyle = { backgroundColor: colorScheme[share.outcomeToken.index] }

--- a/src/containers/MarketDetailPage/index.js
+++ b/src/containers/MarketDetailPage/index.js
@@ -16,18 +16,10 @@ import {
   withdrawFees,
   closeMarket,
 } from 'actions/market'
-import {
-  getMarketById,
-} from 'selectors/market'
-import {
-  getMarketTrades,
-} from 'selectors/marketTrades'
-import {
-  getMarketShares,
-} from 'selectors/marketShares'
-import {
-  getMarketGraph,
-} from 'selectors/marketGraph'
+import { getMarketById } from 'selectors/market'
+import { getMarketTrades } from 'selectors/marketTrades'
+import { getMarketShares } from 'selectors/marketShares'
+import { getMarketGraph } from 'selectors/marketGraph'
 import {
   getCurrentAccount,
   getCurrentBalance,


### PR DESCRIPTION
Sometimes we have outcomes like this: 1, 2, 3. But in `My Tokens` tab it shows it like "2, 1". I added sorting to market shares to make sure they are in right order. Also I fixed few eslint issues in MarketDetailsPage container