### PR TITLE
PM-358: Graphline Fixes, Trade- ordering/visibility bugfixes

### DIFF
--- a/src/components/MarketDetail/marketDetail.less
+++ b/src/components/MarketDetail/marketDetail.less
@@ -134,7 +134,7 @@
 .marketGraph {
   width: 100%;
   min-height: 400px;
-  padding: 120px 0;
+  padding: 60px 0;
   height: 60vh;
   background-color: @bg-color-dark;
   color: @font-color-dark;

--- a/src/components/MarketGraph/index.js
+++ b/src/components/MarketGraph/index.js
@@ -145,14 +145,6 @@ DateAxisTick.propTypes = {
   payload: PropTypes.string,
 }
 
-PercentAxisTick.propTypes = {
-  x: PropTypes.number,
-  y: PropTypes.number,
-  payload: PropTypes.shape({
-    value: PropTypes.number,
-  }),
-}
-
 MarketGraph.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   market: PropTypes.shape({

--- a/src/components/MarketGraph/index.js
+++ b/src/components/MarketGraph/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import { schemeDark2 } from 'd3-scale-chromatic'
-import { scaleOrdinal } from 'd3'
+import { scaleOrdinal, scaleTime } from 'd3'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts'
 import CustomTooltip from 'components/CustomTooltip'
 import { OUTCOME_TYPES, COLOR_SCHEME_DEFAULT } from 'utils/constants'
@@ -11,7 +11,7 @@ import Decimal from 'decimal.js'
 const DateAxisTick = ({ x, y, payload }) => (
   <g transform={`translate(${x}, ${y})`}>
     <text x={0} y={0} dy={16} fill="white" textAnchor="middle">
-      {moment(payload).format('L')}
+      {moment(payload.value).format('L')}
     </text>
   </g>
 )
@@ -30,7 +30,6 @@ const renderCategoricalGraph = (data) => {
   const stacks = Object.keys(data[0]).slice(2)
   const z = scaleOrdinal(schemeDark2)
   z.domain(stacks)
-
   return (
     <div className="marketGraph">
       <div className="container marketGraph__container">
@@ -49,8 +48,14 @@ const renderCategoricalGraph = (data) => {
                 </linearGradient>
               ))}
             </defs>
-            <XAxis className="axis axis--x" dataKey="date" minTickGap={150} tick={DateAxisTick} />
-            <YAxis className="axis axis--y" tick={PercentAxisTick} tickCount={5} />
+            <XAxis
+              className="axis axis--x"
+              dataKey="date"
+              tickSize={0}
+              scale="time"
+              tick={DateAxisTick}
+            />
+            <YAxis className="axis axis--y" tickFormatter={val => (val * 100).toFixed(0)} unit="%" type="number" />
             <Tooltip className="tooltip" content={<CustomTooltip />} />
             <Legend />
             {stacks.map((key, keyIndex) => (
@@ -61,6 +66,7 @@ const renderCategoricalGraph = (data) => {
                 stackId="1"
                 fill={COLOR_SCHEME_DEFAULT[keyIndex]}
                 stroke={COLOR_SCHEME_DEFAULT[keyIndex]}
+                dot={false}
               />
             ))}
           </LineChart>
@@ -93,9 +99,16 @@ const renderScalarGraph = (data, { eventDescription, lowerBound, upperBound }) =
                 </linearGradient>
               ))}
             </defs>
-            <XAxis className="axis axis--x" dataKey="date" minTickGap={150} tick={DateAxisTick} />
+            <XAxis
+              className="axis axis--x"
+              dataKey="date"
+              scale="time"
+              tick={DateAxisTick}
+              domain={[data[0].date, (new Date()).valueOf()]}
+            />
             <YAxis
               className="axis axis--y"
+              unit={eventDescription.unit}
               domain={[
                 Decimal(lowerBound)
                   .div(10 ** eventDescription.decimals)
@@ -114,6 +127,7 @@ const renderScalarGraph = (data, { eventDescription, lowerBound, upperBound }) =
               dataKey="scalarPoint"
               fill={COLOR_SCHEME_DEFAULT[0]}
               stroke={COLOR_SCHEME_DEFAULT[0]}
+              dot={false}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/src/components/MarketGraph/index.js
+++ b/src/components/MarketGraph/index.js
@@ -16,15 +16,7 @@ const DateAxisTick = ({ x, y, payload }) => (
   </g>
 )
 
-const PercentAxisTick = ({ x, y, payload: { value } }) => (
-  <g transform={`translate(${x}, ${y})`}>
-    {(value === 0 || value === 1) && (
-      <text x={0} y={0} dy={5} textAnchor="end" fill="white">
-        {(value * 100).toFixed(0)}%
-      </text>
-    )}
-  </g>
-)
+const percentageFormatter = val => (val * 100).toFixed(0)
 
 const renderCategoricalGraph = (data) => {
   const stacks = Object.keys(data[0]).slice(2)
@@ -55,7 +47,7 @@ const renderCategoricalGraph = (data) => {
               scale="time"
               tick={DateAxisTick}
             />
-            <YAxis className="axis axis--y" tickFormatter={val => (val * 100).toFixed(0)} unit="%" type="number" />
+            <YAxis className="axis axis--y" tickFormatter={percentageFormatter} unit="%" type="number" />
             <Tooltip className="tooltip" content={<CustomTooltip />} />
             <Legend />
             {stacks.map((key, keyIndex) => (

--- a/src/selectors/marketGraph.js
+++ b/src/selectors/marketGraph.js
@@ -9,12 +9,12 @@ const getFirstGraphPoint = (market) => {
   let firstPoint
   if (OUTCOME_TYPES.SCALAR === market.event.type) {
     firstPoint = {
-      date: market.creationDate,
+      date: new Date(market.creationDate).valueOf(),
       scalarPoint: normalizeScalarPoint(['0.5', '0.5'], market),
     }
   } else if (OUTCOME_TYPES.CATEGORICAL === market.event.type) {
     firstPoint = {
-      date: market.creationDate,
+      date: new Date(market.creationDate).valueOf(),
       scalarPoint: undefined,
       ...market.eventDescription.outcomes.reduce((prev, current) => {
         const toReturn = {
@@ -28,26 +28,26 @@ const getFirstGraphPoint = (market) => {
   return firstPoint
 }
 
-const getLastGraphPoint = trades => ({ ...trades[trades.length - 1], date: new Date().toISOString() })
+const getLastGraphPoint = trades => ({ ...trades[trades.length - 1], date: new Date().valueOf() })
 
 export const getMarketGraph = market => createSelector(
   getMarketTrades(market.address),
   (trades) => {
     const firstPoint = getFirstGraphPoint(market)
 
-    const graphPoints = trades.map(trade => trade.marginalPrices.reduce(
+    const graphPoints = trades.reverse().map(trade => trade.marginalPrices.reduce(
       (prev, current, outcomeIndex) => {
         const toReturn = { ...prev }
         toReturn[getOutcomeName(market, outcomeIndex)] = current
         return toReturn
       },
       {
-        date: trade.date,
+        date: new Date(trade.date).valueOf(),
         scalarPoint:
           OUTCOME_TYPES.SCALAR === market.event.type ? normalizeScalarPoint(trade.marginalPrices, market) : undefined,
       },
     ))
-    const lastPoint = trades.length ? getLastGraphPoint(graphPoints) : { ...firstPoint, date: new Date().toISOString() }
+    const lastPoint = trades.length ? getLastGraphPoint(graphPoints) : { ...firstPoint, date: new Date().valueOf() }
 
     return [firstPoint, ...graphPoints, lastPoint]
   },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/969493/33993533-37eaecea-e0d7-11e7-873d-85788734e866.png)

After:
![image](https://user-images.githubusercontent.com/969493/33993537-3e75215c-e0d7-11e7-8dd4-d2741485be6b.png)

Summary of changes:
- Ordering is now fixed for Marketgraph Points (was reverse and also randomly ordered sometimes)
- Trades now always have market information, previously the API didn't return the market for marketDetailTrades, the selector now appends it
- Pointdistance between marketgraph points is now realistic to scale