### PR TITLE
PM-335 Improve buy tokens view

### DIFF
--- a/src/components/MarketBuySharesForm/index.js
+++ b/src/components/MarketBuySharesForm/index.js
@@ -381,9 +381,9 @@ class MarketBuySharesForm extends Component {
                 </div>
               )}
               <div className="row marketBuySharesForm__row">
-                <div className="col-md-6">
+                <div className="col-xs-10 col-xs-offset-1">
                   <InteractionButton
-                    className="btn btn-primary col-md-12"
+                    className="btn btn-primary col-xs-12"
                     disabled={submitDisabled}
                     loading={submitting || local}
                     type="submit"

--- a/src/components/MarketBuySharesForm/index.js
+++ b/src/components/MarketBuySharesForm/index.js
@@ -391,17 +391,6 @@ class MarketBuySharesForm extends Component {
                     Buy Tokens
                   </InteractionButton>
                 </div>
-                <div className="col-md-6">
-                  <button
-                    className="btn btn-default col-md-12 marketBuySharesForm__cancel"
-                    type="button"
-                    onClick={() => {
-                      changeUrl(`/markets/${address}/`)
-                    }}
-                  >
-                    Cancel
-                  </button>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR improves the buy tokens view removing the cancel button and adapting the buy button to new layout (making it bigger)

Mock's link [can be found here](https://app.zeplin.io/project/5a25459d901126c05f08a44a/screen/5a3139dc19b7f48363a8ad27)

NOW: 
![screenshot 2017-12-15 12 24 04](https://user-images.githubusercontent.com/4266059/34040435-fa0be2ae-e193-11e7-9230-0e0b965af27c.png)
![screenshot 2017-12-15 12 24 32](https://user-images.githubusercontent.com/4266059/34040437-fc6f7678-e193-11e7-9e92-c72382800440.png)
