### PR TITLE
PM-366: Do not show uPort login modal for not logged user

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -8,7 +8,6 @@ import Hairline from 'components/layout/Hairline'
 import PageFrame from 'components/layout/PageFrame'
 import TransitionGroup from 'react-transition-group/TransitionGroup'
 import CSSTransition from 'react-transition-group/CSSTransition'
-import LoadingIndicator from 'components/LoadingIndicator'
 import TransactionFloaterContainer from 'containers/TransactionFloaterContainer'
 import HeaderContainer from 'containers/HeaderContainer'
 import { providerPropType } from 'utils/shapes'
@@ -29,16 +28,6 @@ class App extends Component {
 
   render() {
     const { provider } = this.props
-    if (!this.props.blockchainConnection) {
-      return (
-        <div className="appContainer">
-          <div className="loader-container">
-            <LoadingIndicator width={100} height={100} />
-            <h1>Connecting</h1>
-          </div>
-        </div>
-      )
-    }
 
     const currentKey = this.props.location.pathname.split('/')[2] || this.props.location.pathname.split('/')[1] || '/'
     const timeout = { enter: 200, exit: 200 }
@@ -62,7 +51,6 @@ class App extends Component {
 }
 
 App.propTypes = {
-  blockchainConnection: PropTypes.bool,
   children: PropTypes.node,
   location: PropTypes.object,
   provider: providerPropType,
@@ -70,7 +58,6 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   provider: getSelectedProvider(state),
-  blockchainConnection: state.blockchain.connectionTried,
   isConnectedToCorrectNetwork: isConnectedToCorrectNetwork(state),
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import 'less/style.less'
 import AppRouter from 'router'
 import initGoogleAnalytics from 'utils/analytics/init'
 import BackdropProvider from 'containers/BackdropProvider'
-import { isValid, getCredentialsFromLocalStorage } from 'integrations/uport/connector'
+import { areCredentialsValid } from 'integrations/uport/connector'
 import store from 'store'
 import { setMomentRelativeTime } from './setup'
 
@@ -23,7 +23,7 @@ setMomentRelativeTime()
 // load data from localstorage
 store.dispatch({ type: 'INIT' })
 
-const credentialsAreValid = isValid(getCredentialsFromLocalStorage())
+const credentialsAreValid = areCredentialsValid()
 if (credentialsAreValid) {
   store.dispatch(initProviders())
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import 'less/style.less'
 import AppRouter from 'router'
 import initGoogleAnalytics from 'utils/analytics/init'
 import BackdropProvider from 'containers/BackdropProvider'
+import { isValid, getCredentialsFromLocalStorage } from 'integrations/uport/connector'
 import store from 'store'
 import { setMomentRelativeTime } from './setup'
 
@@ -21,7 +22,12 @@ setMomentRelativeTime()
 
 // load data from localstorage
 store.dispatch({ type: 'INIT' })
-store.dispatch(initProviders())
+
+const credentialsAreValid = isValid(getCredentialsFromLocalStorage())
+if (credentialsAreValid) {
+  store.dispatch(initProviders())
+}
+
 Decimal.set({ toExpPos: 9999 })
 
 initGoogleAnalytics()

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -1,9 +1,10 @@
 import { Connect, SimpleSigner } from 'uport-connect'
+import { isValid as isValidPushNotificaiton } from './uportNotifications'
+import { isValid as isValidQrCredential } from './uportQr'
+import { notificationsEnabled } from './connector'
 
 const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
 const LOGIN_TEXT = 'Log into <b>Gnosis Olympia</b>'
-
-export const isValid = cred => !!cred
 
 const uport = new Connect('Gnosis', {
   clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
@@ -15,6 +16,11 @@ export const getCredentialsFromLocalStorage = () => {
   const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
 
   return cred ? JSON.parse(cred) : cred
+}
+
+export const areCredentialsValid = () => {
+  const cred = getCredentialsFromLocalStorage()
+  return notificationsEnabled ? isValidPushNotificaiton(cred) : isValidQrCredential(cred)
 }
 
 const modifyUportLoginModal = (firstReq) => {

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -3,13 +3,15 @@ import { Connect, SimpleSigner } from 'uport-connect'
 const UPORT_OLYMPIA_KEY = 'GNOSIS_OLYMPIA_USER'
 const LOGIN_TEXT = 'Log into <b>Gnosis Olympia</b>'
 
+export const isValid = cred => !!cred
+
 const uport = new Connect('Gnosis', {
   clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
   network: 'rinkeby',
   signer: SimpleSigner('80b6d12233a5dc01ea46ebf773919f2418b44412c6318d0f2b676b3a1c6b634a'),
 })
 
-const getCredentialsFromLocalStorage = () => {
+export const getCredentialsFromLocalStorage = () => {
   const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
 
   return cred ? JSON.parse(cred) : cred

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -5,6 +5,8 @@ import { fetchOlympiaUserData } from 'routes/scoreboard/store/actions'
 import { weiToEth } from 'utils/helpers'
 import initUportConnector from './connector'
 
+export const notificationsEnabled = false
+
 class Uport extends BaseIntegration {
   static providerName = WALLET_PROVIDER.UPORT
 
@@ -14,7 +16,7 @@ class Uport extends BaseIntegration {
    */
   static providerPriority = 100
   static watcherInterval = 5000
-  static USE_NOTIFICATIONS = false
+  static USE_NOTIFICATIONS = notificationsEnabled
 
   constructor() {
     super()

--- a/src/integrations/uport/uportNotifications.js
+++ b/src/integrations/uport/uportNotifications.js
@@ -1,6 +1,6 @@
 import { decodeToken } from 'jsontokens'
 
-const isValid = (cred) => {
+export const isValid = (cred) => {
   if (cred === null) {
     return false
   }

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -1,4 +1,4 @@
-const isValid = cred => !!cred
+import { isValid } from './connector'
 
 const assignSessionProps = (uport, cred) => {
   // eslint-disable-next-line

--- a/src/integrations/uport/uportQr.js
+++ b/src/integrations/uport/uportQr.js
@@ -1,4 +1,4 @@
-import { isValid } from './connector'
+export const isValid = cred => !!cred
 
 const assignSessionProps = (uport, cred) => {
   // eslint-disable-next-line


### PR DESCRIPTION
**BEFORE:**
uPort login modal is shown for not logged user on initial load. He has to close it to start browsing the interface

**AFTER:**
Modal is not shown. He can start using the interface right after the load**