### PR TITLE
PM-375 Fix scoreboard and dashboard account problem

### DIFF
--- a/src/routes/scoreboard/containers/selector.js
+++ b/src/routes/scoreboard/containers/selector.js
@@ -1,5 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect'
-import { firstOlympiaUsersSelectorAsList, nomalizedCurrentAccount, meSelector } from '../store/selectors'
+import { getCurrentAccount } from 'selectors/blockchain'
+import { firstOlympiaUsersSelectorAsList, meSelector } from '../store/selectors'
 
 const usersSelector = createSelector(
   firstOlympiaUsersSelectorAsList,
@@ -22,5 +23,5 @@ const usersSelector = createSelector(
 
 export default createStructuredSelector({
   data: usersSelector,
-  myAccount: nomalizedCurrentAccount,
+  myAccount: getCurrentAccount,
 })

--- a/src/routes/scoreboard/store/selectors/index.js
+++ b/src/routes/scoreboard/store/selectors/index.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect'
 import { getCurrentAccount } from 'selectors/blockchain'
-import { hexWithoutPrefix } from 'utils/helpers'
 
 const olympiaUsersSelectorAsList = (state) => {
   if (!state.olympia) {
@@ -35,13 +34,8 @@ export const firstOlympiaUsersSelectorAsList = createSelector(
     : undefined),
 )
 
-export const nomalizedCurrentAccount = createSelector(
-  getCurrentAccount,
-  account => (account ? hexWithoutPrefix(account) : account),
-)
-
 export const meSelector = createSelector(
   olympiaUsersSelectorAsList,
-  nomalizedCurrentAccount,
+  getCurrentAccount,
   (users, account) => (users ? users.find(user => user.account === account) : undefined),
 )


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR aligns selectors in Scoreboard and indirectly in Dashboard/Metrics components, because of **meSelector** now uses regular (and not normalized) account address. This error was a regression bug.