### PR TITLE
PM-381 Fix reset credentials stored in uport

### DIFF
--- a/src/actions/providers.js
+++ b/src/actions/providers.js
@@ -1,6 +1,5 @@
 import { createAction } from 'redux-actions'
 
-import { UPORT_OLYMPIA_KEY } from 'integrations/uport/connector'
 import { isGnosisInitialized, getSelectedProvider, initializedAllProviders } from 'selectors/blockchain'
 
 import { initGnosis } from './blockchain'
@@ -16,9 +15,6 @@ const GNOSIS_REINIT_KEYS = ['network', 'account', 'available']
 export const logoutProvider = () => async (dispatch, getState) => {
   const state = getState()
   const { name: providerName } = getSelectedProvider(state)
-
-  localStorage.removeItem(UPORT_OLYMPIA_KEY)
-  localStorage.removeItem(`GNOSIS_${process.env.VERSION}`)
 
   await dispatch(logout(providerName))
 }

--- a/src/integrations/uport/connector.js
+++ b/src/integrations/uport/connector.js
@@ -39,11 +39,14 @@ const LoginUport = () => (
   </Block>
 )
 
-const uport = new Connect('Gnosis', {
-  clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
-  network: 'rinkeby',
-  signer: SimpleSigner('80b6d12233a5dc01ea46ebf773919f2418b44412c6318d0f2b676b3a1c6b634a'),
-})
+let uport = null
+export const connect = () => {
+  uport = new Connect('Gnosis', {
+    clientId: '2ozUxc1QzFVo7b51giZsbkEsKw2nJ87amAf',
+    network: 'rinkeby',
+    signer: SimpleSigner('80b6d12233a5dc01ea46ebf773919f2418b44412c6318d0f2b676b3a1c6b634a'),
+  })
+}
 
 export const getCredentialsFromLocalStorage = () => {
   const cred = localStorage.getItem(UPORT_OLYMPIA_KEY)
@@ -81,6 +84,13 @@ const requestCredentials = useNotifications => async () => {
     localStorage.removeItem(UPORT_OLYMPIA_KEY)
     return null
   }
+}
+
+export const connectorLogOut = () => {
+  // localStorage.removeItem(UPORT_OLYMPIA_KEY)
+  // localStorage.removeItem(`GNOSIS_${process.env.VERSION}`)
+  localStorage.clear()
+  connect()
 }
 
 const initUportConnector = async (useNotifications) => {

--- a/src/integrations/uport/index.js
+++ b/src/integrations/uport/index.js
@@ -4,7 +4,7 @@ import { WALLET_PROVIDER } from 'integrations/constants'
 import BaseIntegration from 'integrations/baseIntegration'
 import { fetchOlympiaUserData } from 'routes/scoreboard/store/actions'
 import { weiToEth } from 'utils/helpers'
-import initUportConnector, { isUserConnected } from './connector'
+import initUportConnector, { connect, connectorLogOut, isUserConnected } from './connector'
 
 export const notificationsEnabled = false
 
@@ -21,7 +21,7 @@ class Uport extends BaseIntegration {
 
   constructor() {
     super()
-
+    connect()
     this.watcher = setInterval(() => {
       this.watch('balance', this.getBalance)
       this.watch('network', this.getNetwork)
@@ -88,6 +88,11 @@ class Uport extends BaseIntegration {
     }
 
     throw new Error('Invalid Balance')
+  }
+
+  async logout() {
+    await super.logout()
+    connectorLogOut()
   }
 }
 


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [ ] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR solves the situation when a user logs out of the app and then tries to sign in but does not scan the code. Because we previously stored manually credentials inside the uport object the app was able to recognise the user and therefore load his/her credentials anyway.

I have refactored a bit the logout process moving the code for clearing the storage to uport/connector class. 