### PR TITLE
Fix Webpack uglify speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build-dev": "NODE_ENV=development ./node_modules/.bin/webpack -p --config webpack.dev.config.js",
-    "build-prod": "NODE_ENV=production ./node_modules/.bin/webpack -p --config webpack.prod.config.js",
+    "build-prod": "NODE_ENV=production ./node_modules/.bin/webpack -p --progress --config webpack.prod.config.js",
     "build": "if test \"$NODE_ENV\" = \"production\" ; then npm run build-prod; else npm run build-dev; fi ",
     "clean": "rm -rf dist",
     "start-dev": "node_modules/.bin/webpack-dev-server --hot --host 0.0.0.0 --client-log-level info --config webpack.dev.config.js --progress",
@@ -129,7 +129,7 @@
     "storybook-router": "^0.3.1",
     "style-loader": "^0.13.2",
     "truffle-hdwallet-provider": "0.0.3",
-    "uglifyjs-webpack-plugin": "^1.0.1",
+    "uglifyjs-webpack-plugin": "^1.1.4",
     "url-loader": "^0.5.9",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.4"

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -100,6 +100,10 @@ module.exports = {
     }),
     new UglifyJsWebpackPlugin({
       sourceMap: true,
+      parallel: true,
+      uglifyOptions: {
+        compress: false,
+      },
     }),
   ],
 }


### PR DESCRIPTION
This PR enables parallelisation and removes compression on files when running the UglifyPlugin in the prod webpack file. 

Had to do this because compilation was stuck compiling assets.