### PR TITLE
BUG: Prevent redirect to market list after refresh on the dashboard

### DIFF
--- a/src/containers/DashboardPage/index.js
+++ b/src/containers/DashboardPage/index.js
@@ -1,24 +1,15 @@
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 
-
 import DashboardPage from 'components/Dashboard'
-import {
-  getAccountPredictiveAssets,
-  getMarkets,
-} from 'selectors/market'
-import {
-  getAccountTrades,
-} from 'selectors/marketTrades'
-import {
-  getAccountShares,
-} from 'selectors/marketShares'
-import { getCurrentAccount, getEtherTokensAmount, isGnosisInitialized, checkWalletConnection } from 'selectors/blockchain'
+import { getAccountPredictiveAssets, getMarkets } from 'selectors/market'
+import { getAccountTrades } from 'selectors/marketTrades'
+import { getAccountShares } from 'selectors/marketShares'
+import { getCurrentAccount, getEtherTokensAmount, isGnosisInitialized } from 'selectors/blockchain'
 import { requestMarkets, requestAccountTrades, requestAccountShares, redeemWinnings } from 'actions/market'
 import { requestGasPrice, requestEtherTokens } from 'actions/blockchain'
 import { weiToEth } from 'utils/helpers'
 import { areCredentialsValid } from 'integrations/uport/connector'
-
 
 const mapStateToProps = (state) => {
   const markets = getMarkets(state)

--- a/src/containers/DashboardPage/index.js
+++ b/src/containers/DashboardPage/index.js
@@ -17,6 +17,7 @@ import { getCurrentAccount, getEtherTokensAmount, isGnosisInitialized, checkWall
 import { requestMarkets, requestAccountTrades, requestAccountShares, redeemWinnings } from 'actions/market'
 import { requestGasPrice, requestEtherTokens } from 'actions/blockchain'
 import { weiToEth } from 'utils/helpers'
+import { areCredentialsValid } from 'integrations/uport/connector'
 
 
 const mapStateToProps = (state) => {
@@ -26,6 +27,7 @@ const mapStateToProps = (state) => {
   const accountPredictiveAssets = weiToEth(getAccountPredictiveAssets(state, defaultAccount))
   const accountShares = getAccountShares(state)
   const gnosisInitialized = isGnosisInitialized(state)
+  const validCredentials = areCredentialsValid()
   let etherTokens = getEtherTokensAmount(state, defaultAccount)
 
   if (etherTokens !== undefined) {
@@ -35,7 +37,7 @@ const mapStateToProps = (state) => {
   }
 
   return {
-    hasWallet: checkWalletConnection(state),
+    hasWallet: validCredentials,
     defaultAccount,
     markets,
     etherTokens,


### PR DESCRIPTION
**BEFORE:**
If you refresh the page while you're on the dashboard, you will be redirected to market list

**AFTER:**
If you refresh the page while you're on the dashboard, you won't be redirected

Actual changes are on line `12, 21, 31` other are just codestyle fixes