### PR TITLE
Bug: PM-390 Pagination issue with MarketGraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "sha1": "^1.1.1",
     "truffle-contract": "^3.0.0",
     "uport-connect": "gnosis/uport-connect#testing",
-    "url-parse": "^1.2.0",
     "uuid": "^3.1.0",
     "web3": "0.18.4"
   },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "sha1": "^1.1.1",
     "truffle-contract": "^3.0.0",
     "uport-connect": "gnosis/uport-connect#testing",
+    "url-parse": "^1.2.0",
     "uuid": "^3.1.0",
     "web3": "0.18.4"
   },

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -1,53 +1,47 @@
-import {
-  restFetch,
-  restFetchAllPages,
-  hexWithoutPrefix,
-} from 'utils/helpers'
+import { hexWithoutPrefix } from 'utils/helpers'
 import { normalize } from 'normalizr'
-import qs from 'querystring'
-import { marketSchema, marketSharesSchema, marketTradesSchema } from './schema'
+import { requestFromRestAPI, requestFromRestAPIAllPages } from 'utils/fetch'
 
-const API_URL = `${process.env.GNOSISDB_URL}/api`
+import { marketSchema, marketSharesSchema, marketTradesSchema } from './schema'
 
 // TODO The default assignment is because JEST test do not work out of the box with ENV variables. Fix that using the plugin dotenv(for example)
 const addresses = Object.keys(process.env.WHITELIST || {}).map(address => hexWithoutPrefix(address))
-const whitelistedAddressesFilter = qs.stringify({ creator: addresses.join() }, ',')
 
-export const requestMarket = async marketAddress =>
-  restFetch(`${API_URL}/markets/${hexWithoutPrefix(marketAddress)}/`).then(response =>
-    normalize({ ...response, local: false }, marketSchema))
-
-export const requestMarkets = async () => {
-  const url = `${API_URL}/markets/?${whitelistedAddressesFilter}`
-
-  return restFetch(url).then(response =>
-    normalize(response.results.filter(market => typeof market.funding !== 'undefined'), [marketSchema]))
+export const requestMarket = async (marketAddress) => {
+  const payload = await requestFromRestAPI(`markets/${hexWithoutPrefix(marketAddress)}/`)
+  return normalize({ ...payload, local: false }, marketSchema)
 }
 
-export const requestFactories = async () => restFetch(`${API_URL}/factories`)
+
+export const requestMarkets = async () => {
+  const payload = await requestFromRestAPI('markets/', { creator: addresses.join() })
+  return normalize(payload.results.filter(market => typeof market.funding !== 'undefined'), [marketSchema])
+}
+
+export const requestFactories = async () => requestFromRestAPI('factories')
 
 export const requestMarketTradesForAccount = async (marketAddress, accountAddress) => {
-  const payload = await restFetch(`${API_URL}/markets/${hexWithoutPrefix(marketAddress)}/trades/${hexWithoutPrefix(accountAddress)}`)
+  const payload = await requestFromRestAPI(`markets/${hexWithoutPrefix(marketAddress)}/trades/${hexWithoutPrefix(accountAddress)}`)
   return normalize(payload.results, [marketTradesSchema])
 }
 
 export const requestMarketTrades = async (market) => {
-  const payload = await restFetchAllPages(`${API_URL}/markets/${hexWithoutPrefix(market.address)}/trades/`, 200)
+  const payload = await requestFromRestAPIAllPages(`markets/${hexWithoutPrefix(market.address)}/trades/`, {}, 200)
   return normalize(payload.results, [marketTradesSchema])
 }
 
 export const requestAccountTrades = async (accountAddress) => {
-  const payload = await restFetch(`${API_URL}/account/${hexWithoutPrefix(accountAddress)}/trades/`)
+  const payload = await requestFromRestAPI(`account/${hexWithoutPrefix(accountAddress)}/trades/`)
   return normalize(payload.results.map(trade => ({ ...trade, owner: accountAddress })), [marketTradesSchema])
 }
 
 
 export const requestAccountShares = async (address) => {
-  const payload = await restFetch(`${API_URL}/account/${hexWithoutPrefix(address)}/shares/`)
+  const payload = await requestFromRestAPI(`account/${hexWithoutPrefix(address)}/shares/`)
   return normalize(payload.results, [marketSharesSchema])
 }
 
 export const requestMarketShares = async (marketAddress, accountAddress) => {
-  const payload = await restFetch(`${API_URL}/markets/${hexWithoutPrefix(marketAddress)}/shares/${hexWithoutPrefix(accountAddress)}/`)
+  const payload = await requestFromRestAPI(`markets/${hexWithoutPrefix(marketAddress)}/shares/${hexWithoutPrefix(accountAddress)}/`)
   return normalize(payload.results, [marketSharesSchema])
 }

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -1,12 +1,9 @@
 import {
   restFetch,
+  restFetchAllPages,
   hexWithoutPrefix,
-  addIdToObjectsInArray,
-  getOutcomeName,
-  normalizeScalarPoint,
 } from 'utils/helpers'
 import { normalize } from 'normalizr'
-import { OUTCOME_TYPES } from 'utils/constants'
 import qs from 'querystring'
 import { marketSchema, marketSharesSchema, marketTradesSchema } from './schema'
 
@@ -35,7 +32,7 @@ export const requestMarketTradesForAccount = async (marketAddress, accountAddres
 }
 
 export const requestMarketTrades = async (market) => {
-  const payload = await restFetch(`${API_URL}/markets/${hexWithoutPrefix(market.address)}/trades/`)
+  const payload = await restFetchAllPages(`${API_URL}/markets/${hexWithoutPrefix(market.address)}/trades/`, 200)
   return normalize(payload.results, [marketTradesSchema])
 }
 

--- a/src/components/CustomTooltip/index.js
+++ b/src/components/CustomTooltip/index.js
@@ -109,7 +109,7 @@ const CustomTooltip = ({
 
 CustomTooltip.propTypes = {
   payload: PropTypes.array,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   active: PropTypes.bool,
   separator: PropTypes.string,
   itemStyle: PropTypes.object,

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -28,20 +28,12 @@ import { marketShareShape, marketTradeShape, gasCostsShape } from '../../utils/s
 
 const ONE_WEEK_IN_HOURS = 168
 
-const LOADING_STATE = {
-  UNKNOWN: 'unknown',
-  RUNNING: 'running',
-  SUCCESS: 'success',
-  FAILURE: 'failure',
-}
-
 class MarketDetail extends Component {
   constructor(props) {
     super(props)
 
     this.state = {
       marketFetchError: undefined,
-      marketGraphLoading: LOADING_STATE.UNKNOWN,
     }
   }
 
@@ -75,20 +67,6 @@ class MarketDetail extends Component {
     }
   }
 
-  async fetchMarketGraph(firstFetch) {
-    if (firstFetch) {
-      await this.setState({ marketGraphLoading: LOADING_STATE.RUNNING })
-    }
-
-    await this.props.fetchMarketTrades(this.props.market)
-
-    try {
-      await this.setState({ marketGraphLoading: LOADING_STATE.SUCCESS })
-    } catch (e) {
-      await this.setState({ marketGraphLoading: LOADING_STATE.FAILURE })
-    }
-  }
-
   // Check available views on first fetch
   @autobind
   fetchEssentialData(firstFetch = false) {
@@ -96,7 +74,7 @@ class MarketDetail extends Component {
       .fetchMarket()
       .then(() => {
         this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
-        this.fetchMarketGraph()
+        this.props.fetchMarketTrades(this.props.market)
 
         if (this.props.defaultAccount) {
           this.props.fetchMarketShares(this.props.defaultAccount)
@@ -322,16 +300,16 @@ class MarketDetail extends Component {
 
   renderMarketGraph() {
     const { market, marketGraph } = this.props
-    const canRenderMarketGraph = marketGraph && this.state.marketGraphLoading === LOADING_STATE.SUCCESS
-
-    if (canRenderMarketGraph) {
-      return <MarketGraph data={marketGraph} market={market} />
+    if (!marketGraph.length) {
+      return (
+        <div className="container">
+          <LoadingIndicator className="marketGraph__spinner" />
+        </div>
+      )
     }
 
     return (
-      <div className="container">
-        <LoadingIndicator className="marketGraph__spinner" />
-      </div>
+      <MarketGraph data={marketGraph} market={market} />
     )
   }
 

--- a/src/components/MarketDetail/marketDetail.less
+++ b/src/components/MarketDetail/marketDetail.less
@@ -138,7 +138,14 @@
   height: 60vh;
   background-color: @bg-color-dark;
   color: @font-color-dark;
+
+  &__spinner {
+    margin: auto;
+    display: block;
+    padding: 60px 0;
+  }
 }
+
 
 .expandable {
   position: relative;

--- a/src/routes/scoreboard/store/actions/fetchOlympiaUserData.js
+++ b/src/routes/scoreboard/store/actions/fetchOlympiaUserData.js
@@ -1,11 +1,8 @@
-import { restFetch } from 'utils/helpers'
+import { requestFromRestAPI } from 'utils/fetch'
 import addUsers from './addUsers'
 
-const API_URL = `${process.env.GNOSISDB_URL}/api`
-const url = `${API_URL}/scoreboard/`
-
 export default account => dispatch =>
-  restFetch(url + account)
+  requestFromRestAPI(`scoreboard/${account}`)
     .then((response) => {
       if (!response) {
         dispatch(addUsers([]))

--- a/src/routes/scoreboard/store/actions/fetchOlympiaUsers.js
+++ b/src/routes/scoreboard/store/actions/fetchOlympiaUsers.js
@@ -1,11 +1,8 @@
-import { restFetch } from 'utils/helpers'
+import { requestFromRestAPI } from 'utils/fetch'
 import addUsers from './addUsers'
 
-const API_URL = `${process.env.GNOSISDB_URL}/api`
-const url = `${API_URL}/scoreboard/`
-
 export default () => dispatch =>
-  restFetch(url)
+  requestFromRestAPI('scoreboard')
     .then((response) => {
       if (!response) {
         dispatch(addUsers([]))

--- a/src/selectors/marketGraph.js
+++ b/src/selectors/marketGraph.js
@@ -35,6 +35,10 @@ export const getMarketGraph = market => createSelector(
   (trades) => {
     const firstPoint = getFirstGraphPoint(market)
 
+    if (!trades.length) {
+      return []
+    }
+
     const graphPoints = trades.reverse().map(trade => trade.marginalPrices.reduce(
       (prev, current, outcomeIndex) => {
         const toReturn = { ...prev }

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,0 +1,59 @@
+/* globals fetch */
+import qs from 'querystring'
+
+const API_URL = `${process.env.GNOSISDB_URL}/api`
+
+export const requestFromRestAPI = async (endpoint, queryparams) => {
+  const url = `${API_URL}/${endpoint}?${qs.stringify(queryparams)}`
+  const response = await fetch(url)
+
+  if (response.status > 400) {
+    console.warn(`Couldn't fetch ${url}: ${response.status}: ${response.statusText}`)
+    throw new Error('GnosisDB: Couldn\'t fetch (invalid statuscode)')
+  }
+
+  let json
+  try {
+    json = response.json()
+  } catch (e) {
+    console.warn(`Couldn't format response to JSON: ${url}: ${response.body}`)
+    throw new Error('GnosisDB: Couldn\'t fetch (format error)')
+  }
+
+  return json
+}
+
+export const requestFromRestAPIPage = async (endpoint, queryparams = {}, page = 0, pageSize = 100) =>
+  requestFromRestAPI(endpoint, {
+    ...queryparams,
+    limit: pageSize,
+    size: pageSize,
+    offset: page * pageSize,
+  })
+
+export const requestFromRestAPIAllPages = async (endpoint, queryparams, pageSize) => {
+  let page = 0
+  const request = requestFromRestAPIPage(endpoint, queryparams, page, pageSize)
+  const payload = await request
+
+  const allPageRequests = [request]
+
+  let processedCount = payload.results.length
+
+  while (processedCount < payload.count) {
+    page += 1
+    processedCount += payload.results.length
+    allPageRequests.push(requestFromRestAPIPage(endpoint, queryparams, page, pageSize))
+  }
+
+  const results = []
+  const pageRequests = await Promise.all(allPageRequests)
+  pageRequests.forEach((pageRequest) => {
+    results.push(...pageRequest.results)
+  })
+
+  return {
+    results,
+    count: results.length,
+  }
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,5 +1,3 @@
-/* globals fetch */
-
 import { mapValues, startsWith, isArray, range } from 'lodash'
 import seedrandom from 'seedrandom'
 import Decimal from 'decimal.js'
@@ -109,50 +107,6 @@ export const addIdToObjectsInArray = (arrayData) => {
     item._id = index
   })
   return arrayData
-}
-
-export const restFetch = url =>
-  fetch(url)
-    .then(res => new Promise((resolve, reject) => (res.status >= 400 ? reject(res.statusText) : resolve(res))))
-    .then(res => res.json())
-    .catch(err =>
-      new Promise((resolve, reject) => {
-        console.warn(`Gnosis DB: ${err}`)
-        reject(err)
-      }))
-
-export const restFetchPage = async (url, page, pageSize) => {
-  const urlParams = new URLParse(url, null, true)
-  urlParams.query = {
-    limit: pageSize,
-    size: pageSize,
-    offset: page * pageSize,
-  }
-
-  return restFetch(urlParams.toString())
-}
-
-export const restFetchAllPages = async (url, pageSize) => {
-  let page = 0
-  const request = restFetchPage(url, page, pageSize)
-  const payload = await request
-
-  const allPageRequests = [request]
-
-  let processedCount = payload.results.length
-
-  while (processedCount < payload.count) {
-    page += 1
-    processedCount += payload.results.length
-    allPageRequests.push(restFetchPage(url, page, pageSize))
-  }
-
-  const results = [].concat(...((await Promise.all(allPageRequests)).map(requestPayload => requestPayload.results)))
-
-  return {
-    results,
-    count: results.length,
-  }
 }
 
 export const bemifyClassName = (className, element, modifier) => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -134,19 +134,20 @@ export const restFetchPage = async (url, page, pageSize) => {
 
 export const restFetchAllPages = async (url, pageSize) => {
   let page = 0
-  const payload = await restFetchPage(url, page, pageSize)
+  const request = restFetchPage(url, page, pageSize)
+  const payload = await request
 
-  const extraRequests = []
+  const allPageRequests = [request]
 
   let processedCount = payload.results.length
 
   while (processedCount < payload.count) {
     page += 1
     processedCount += payload.results.length
-    extraRequests.push(restFetchPage(url, page, pageSize))
+    allPageRequests.push(restFetchPage(url, page, pageSize))
   }
 
-  const results = [].concat(...((await Promise.all(extraRequests)).map(requestPayload => requestPayload.results)))
+  const results = [].concat(...((await Promise.all(allPageRequests)).map(requestPayload => requestPayload.results)))
 
   return {
     results,

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,6 @@ import moment from 'moment'
 import { HEX_VALUE_REGEX, OUTCOME_TYPES, MARKET_STAGES } from 'utils/constants'
 import { WALLET_PROVIDER } from 'integrations/constants'
 import Web3 from 'web3'
-import URLParse from 'url-parse'
 import Uport from 'integrations/uport'
 
 import dictionary from 'randomNames.json'
@@ -172,7 +171,7 @@ export const getGnosisJsOptions = (provider) => {
 export const promisify = (func, params, timeout) =>
   new Promise((resolve, reject) => {
     if (timeout) {
-      setTimeout(() => reject('Promise timed out'), timeout)
+      setTimeout(() => reject(new Error('Promise timed out')), timeout)
     }
 
     func(...params, (err, res) => {


### PR DESCRIPTION
Because the MarketGraph might fetch ~500 Entities from the Database, Pagination becomes an issue.

## Changes:
- Added new helper function called `restFetchAllPages` and `restFetchPage` to either get all pages or a specific page from REST-API urls.
- Added loading spinner for MarketGraph because loading may now take longer (previously showed empty graph, looked like a bug)

## Before:
![image](https://user-images.githubusercontent.com/969493/34528661-d966cdf0-f0a9-11e7-9db5-8facbaa4daf0.png)


## After:
![image](https://user-images.githubusercontent.com/969493/34528682-e57c1ca8-f0a9-11e7-88ca-0bd8226fe583.png)
