### PR TITLE
PM-393: Fix market graph, fix trades disappearing/showing up again

### DIFF
--- a/src/actions/market.js
+++ b/src/actions/market.js
@@ -119,21 +119,8 @@ export const requestMarketTradesForAccount = (marketAddress, accountAddress) => 
  * Requests all trades (tradehistory) on a market from GnosisDB.
  * @param {Market} market
  */
-export const requestMarketTrades = market => async (dispatch, getState) => {
+export const requestMarketTrades = market => async (dispatch) => {
   const payload = await api.requestMarketTrades(market)
-
-  const state = getState()
-  const newTrades = payload.entities.marketTrades
-  const storedTrades = state.entities.marketTrades
-
-  if (storedTrades) {
-    Object.keys(storedTrades).forEach((id) => {
-      const ownerNeedsToBeFixed = newTrades[id] && !newTrades[id].owner && storedTrades[id].owner
-      if (ownerNeedsToBeFixed) {
-        newTrades[id].owner = storedTrades[id].owner
-      }
-    })
-  }
   return dispatch(receiveEntities(payload))
 }
 

--- a/src/actions/market.js
+++ b/src/actions/market.js
@@ -5,25 +5,18 @@ import uuid from 'uuid/v4'
 import * as api from 'api'
 
 import { receiveEntities, updateEntity } from 'actions/entities'
-
+import { openModal, closeModal } from 'actions/modal'
 import { refreshTokenBalance } from 'actions/blockchain'
-
 import { startLog, closeLog, closeEntrySuccess, closeEntryError } from 'actions/transactions'
 
 import { createEventDescriptionModel, createOracleModel, createEventModel, createMarketModel } from 'api/models'
-
 import { eventDescriptionSchema, eventSchema, oracleSchema, marketSchema } from 'api/schema'
 
-import { OUTCOME_TYPES, TRANSACTION_COMPLETE_STATUS, MARKET_STAGES } from 'utils/constants'
-
-import { DEPOSIT, SELL, REVOKE_TOKENS } from 'utils/transactionExplanations'
-
-import { openModal, closeModal } from 'actions/modal'
+import { OUTCOME_TYPES, TRANSACTION_COMPLETE_STATUS, MARKET_STAGES, MAX_ALLOWANCE_WEI } from 'utils/constants'
+import { DEPOSIT, SELL, REVOKE_TOKENS, SETTING_ALLOWANCE } from 'utils/transactionExplanations'
 import gaSend from 'utils/analytics/gaSend'
 
-import { MAX_ALLOWANCE_WEI } from '../utils/constants'
-import { SETTING_ALLOWANCE } from '../utils/transactionExplanations'
-import { getRedeemedShares } from '../selectors/market'
+import { getRedeemedShares } from 'selectors/market'
 
 /**
  * Constant names for marketcreation stages
@@ -126,8 +119,21 @@ export const requestMarketTradesForAccount = (marketAddress, accountAddress) => 
  * Requests all trades (tradehistory) on a market from GnosisDB.
  * @param {Market} market
  */
-export const requestMarketTrades = marketAddress => async (dispatch) => {
-  const payload = await api.requestMarketTrades(marketAddress)
+export const requestMarketTrades = market => async (dispatch, getState) => {
+  const payload = await api.requestMarketTrades(market)
+
+  const state = getState()
+  const newTrades = payload.entities.marketTrades
+  const storedTrades = state.entities.marketTrades
+
+  if (storedTrades) {
+    Object.keys(storedTrades).forEach((id) => {
+      const ownerNeedsToBeFixed = newTrades[id] && !newTrades[id].owner && storedTrades[id].owner
+      if (ownerNeedsToBeFixed) {
+        newTrades[id].owner = storedTrades[id].owner
+      }
+    })
+  }
   return dispatch(receiveEntities(payload))
 }
 
@@ -375,7 +381,7 @@ export const sellMarketShares = (market, share, outcomeTokenCount, earnings) => 
   const outcomeCountWei = Decimal(outcomeTokenCount).mul(1e18)
   const approvalResetAmount = outcomeCountWei.gte(marketAllowance.toString()) ? MAX_ALLOWANCE_WEI : null
 
-  const payload = (await api.requestMarket(market.address))
+  const payload = await api.requestMarket(market.address)
   const updatedMarket = payload.entities.markets[market.address]
   const updatedPrice = updatedMarket.marginalPrices[outcomeIndex]
   const oldPrice = market.marginalPrices[outcomeIndex]
@@ -477,8 +483,8 @@ export const redeemWinnings = market => async (dispatch, getState) => {
     console.log('winnings: ', await api.redeemWinnings(market.event.type, market.event.address))
     await dispatch(closeEntrySuccess(transactionId, TRANSACTION_STAGES.GENERIC))
 
-    Object.keys(redeemedShares)
-      .forEach(shareId => dispatch(updateEntity({ entityType: 'marketShares', data: { id: shareId, balance: '0' } })))
+    Object.keys(redeemedShares).forEach(shareId =>
+      dispatch(updateEntity({ entityType: 'marketShares', data: { id: shareId, balance: '0' } })))
   } catch (e) {
     console.error(e)
     await dispatch(closeEntryError(transactionId, TRANSACTION_STAGES.GENERIC, e))

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -1,6 +1,7 @@
 import { hexWithoutPrefix } from 'utils/helpers'
 import { normalize } from 'normalizr'
 import { requestFromRestAPI, requestFromRestAPIAllPages } from 'utils/fetch'
+import moment from 'moment'
 
 import { marketSchema, marketSharesSchema, marketTradesSchema } from './schema'
 
@@ -26,11 +27,17 @@ export const requestMarketTradesForAccount = async (marketAddress, accountAddres
 }
 
 export const requestMarketTrades = async (market) => {
-  const payload = await requestFromRestAPIAllPages(`markets/${hexWithoutPrefix(market.address)}/trades/`, {}, 200)
+  const requestParameters = {
+    creation_date_time_0: moment(market.creationDate).format('YYYY-MM-DD hh:mm:ss'),
+    creation_date_time_1: moment(market.eventDescription.resolutionDate).format('YYYY-MM-DD hh:mm:ss'),
+    ordering: '-creation_date_order',
+  }
+  const payload = await requestFromRestAPIAllPages(`markets/${hexWithoutPrefix(market.address)}/trades/`, requestParameters, 200, 500)
   return normalize(payload.results, [marketTradesSchema])
 }
 
 export const requestAccountTrades = async (accountAddress) => {
+  console.log(accountAddress)
   const payload = await requestFromRestAPI(`account/${hexWithoutPrefix(accountAddress)}/trades/`)
   return normalize(payload.results.map(trade => ({ ...trade, owner: accountAddress })), [marketTradesSchema])
 }

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -37,7 +37,6 @@ export const requestMarketTrades = async (market) => {
 }
 
 export const requestAccountTrades = async (accountAddress) => {
-  console.log(accountAddress)
   const payload = await requestFromRestAPI(`account/${hexWithoutPrefix(accountAddress)}/trades/`)
   return normalize(payload.results.map(trade => ({ ...trade, owner: accountAddress })), [marketTradesSchema])
 }

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -74,13 +74,7 @@ class MarketDetail extends Component {
       .fetchMarket()
       .then(() => {
         this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
-        if (this.props.defaultAccount) {
-          this.props.fetchMarketShares(this.props.defaultAccount).then(() => {
-            this.props.fetchMarketTrades(this.props.market)
-          })
-        } else {
-          this.props.fetchMarketTrades(this.props.market)
-        }
+        this.props.fetchMarketTrades(this.props.market)
 
         if (firstFetch) {
           const availableView = this.getAvailableView()

--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -74,11 +74,14 @@ class MarketDetail extends Component {
       .fetchMarket()
       .then(() => {
         this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
-        this.props.fetchMarketTrades(this.props.market)
-
         if (this.props.defaultAccount) {
-          this.props.fetchMarketShares(this.props.defaultAccount)
+          this.props.fetchMarketShares(this.props.defaultAccount).then(() => {
+            this.props.fetchMarketTrades(this.props.market)
+          })
+        } else {
+          this.props.fetchMarketTrades(this.props.market)
         }
+
         if (firstFetch) {
           const availableView = this.getAvailableView()
           if (availableView) {
@@ -186,7 +189,10 @@ class MarketDetail extends Component {
       .local()
       .diff(moment(), 'hours')
     const { marketShares, gasCosts: { redeemWinnings: redeemWinningsGasCost }, gasPrice } = this.props
-    const winningsTotal = Object.keys(marketShares).reduce((acc, shareId) => acc.add(Decimal(marketShares[shareId].winnings || '0')), Decimal(0))
+    const winningsTotal = Object.keys(marketShares).reduce(
+      (acc, shareId) => acc.add(Decimal(marketShares[shareId].winnings || '0')),
+      Decimal(0),
+    )
     const marketClosed = isMarketClosed(market)
     const marketResolved = isMarketResolved(market)
     const showWinning = marketResolved
@@ -240,7 +246,8 @@ class MarketDetail extends Component {
                 <div className="redeemWinning__icon icon icon--achievementBadge" />
                 <div className="redeemWinning__details">
                   <div className="redeemWinning__heading">
-                    <DecimalValue value={weiToEth(winningsTotal)} /> {collateralTokenToText(market.event.collateralToken)}
+                    <DecimalValue value={weiToEth(winningsTotal)} />{' '}
+                    {collateralTokenToText(market.event.collateralToken)}
                   </div>
                   <div className="redeemWinning__label">Your Winnings</div>
                 </div>
@@ -308,9 +315,7 @@ class MarketDetail extends Component {
       )
     }
 
-    return (
-      <MarketGraph data={marketGraph} market={market} />
-    )
+    return <MarketGraph data={marketGraph} market={market} />
   }
 
   render() {
@@ -353,9 +358,7 @@ class MarketDetail extends Component {
         >
           {this.renderExpandableContent()}
         </div>
-        <div>
-          {this.renderMarketGraph()}
-        </div>
+        <div>{this.renderMarketGraph()}</div>
       </div>
     )
   }

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -31,7 +31,7 @@ export const requestFromRestAPIPage = async (endpoint, queryparams = {}, page = 
     offset: page * pageSize,
   })
 
-export const requestFromRestAPIAllPages = async (endpoint, queryparams, pageSize) => {
+export const requestFromRestAPIAllPages = async (endpoint, queryparams, pageSize, limit = 100000) => {
   let page = 0
   const request = requestFromRestAPIPage(endpoint, queryparams, page, pageSize)
   const payload = await request
@@ -40,7 +40,7 @@ export const requestFromRestAPIAllPages = async (endpoint, queryparams, pageSize
 
   let processedCount = payload.results.length
 
-  while (processedCount < payload.count) {
+  while (processedCount < payload.count && processedCount < limit) {
     page += 1
     processedCount += payload.results.length
     allPageRequests.push(requestFromRestAPIPage(endpoint, queryparams, page, pageSize))


### PR DESCRIPTION
So, the problem with trades was:
If we fetch all market trades, the trade will look like the following:
```json
{  
   "date":"2017-12-27T14:08:35",
   "netOutcomeTokensSold":[  
      "10181660606727031484142",
      "9023756987006196098051"
   ],
   "marginalPrices":[  
      "0.8327",
      "0.1673"
   ],
   "outcomeToken":{  
      "event":"d4adbdf647335327cf231fed7fb1407cf38b3d9f",
      "index":0,
      "totalSupply":"5812768581141238739979",
      "address":"9c7d1e98fecf42b3038a49dd394c55d3c0a9a002"
   },
   "outcomeTokenCount":"11773816776166068498",
   "orderType":"BUY",
   "cost":"9791134810933627869",
   "profit":"None",
   "eventDescription":{  
      "ipfsHash":"QmZHYAmaLpkJohRHgeHyXEgkrBtXzXV31yDvodQyHw3748",
      "description":"How many active users will have traded (bought or sold shares) on the Olympia platform by January 1st, 2018 at 12:00 UTC? The number of users will be counted as the total number of unique active users who interacted with the Olympia platform. This information will be obtained from GnosisDB.",
      "title":"How many active users will Olympia have by January 1st, 2018?",
      "resolutionDate":"2018-01-01T12:00:00",
      "decimals":0,
      "unit":"Users"
   }
}
```
But if we fetch market's trades filtered by user's address, it will look like this:
```json
{  
   "date":"2017-12-26T09:28:37",
   "outcomeToken":{  
      "event":"d4adbdf647335327cf231fed7fb1407cf38b3d9f",
      "index":0,
      "totalSupply":"5812768581141238739979",
      "address":"9c7d1e98fecf42b3038a49dd394c55d3c0a9a002"
   },
   "outcomeTokenCount":"559227822465387006634",
   "market":"0x523072360d1fa741fe9d269083bc68191457158e",
   "owner":"0xe1ac24341915945be528af0c54aed72355a34ef6",
   "orderType":"BUY",
   "profit":"None",
   "cost":"463809523809523809149",
   "marginalPrices":[  
      "0.8792",
      "0.1208"
   ]
}
```
The difference is the `owner` property, as we store the trades in the same place, owner property gets removed and then set again after we fetch market's trades filtered by user's account. This leads trades to disappear/appear again. What I did is when fetching all market's trades, I check in the store if we have owner's address associated with the trade and if we do, I set owner property manually. This feels a bit hacky, but I couldn't figure out a better solution. Also I changed the order of requests in `MarketDetails` component to fetch market's trades by user's address first. 

**Actual changes:**
- `src/actions/market.js` line 122-136
- `src/api/rest.js` line 30-35
- `src/components/MarketDetail/index.js` - line 78-82
- `src/utils/fetch.js` - all changed lines

**BEFORE:**
Market graph is showing only user's trades and not all market trades and trades in `My trades` tab are disappearing.

**AFTER**:
Market graph is all market trades and trades in `My trades` tab are not disappearing.